### PR TITLE
Confine GRUB providers to presence of menus, prefer GRUB 2

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub.rb
+++ b/lib/puppet/provider/kernel_parameter/grub.rb
@@ -13,6 +13,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub, :parent => Puppet::Type.type
   lens { 'Grub.lns' }
 
   confine :feature => :augeas
+  confine :exists => target
 
   # Useful XPath to match only recovery entries
   MODE_RECOVERY = "(kernel/S or kernel/1 or kernel/single or .=~regexp('.*\((single-user|recovery) mode\).*'))"

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -19,7 +19,13 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
   end
 
   confine :feature => :augeas
+  confine :exists => target
   commands :mkconfig => mkconfig_path
+
+  # when both grub* providers match, prefer GRUB 2
+  def self.specificity
+    super + 1
+  end
 
   def self.instances
     augopen do |aug|


### PR DESCRIPTION
On a GRUB 2 system, the GRUB 1 provider will always match as it's only confined
on the presence of Augeas and so the behaviour is often random, it might choose
the older provider:

    Warning: Found multiple default providers for kernel_parameter: grub,
    grub2; using grub

Since we'll never create GRUB configurations from scratch, it makes sense to
confine these providers to their files, and prefer GRUB 2 over GRUB 1.