### PR TITLE
Adding support for bootmode 'default'

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,14 @@ both GRUB Legacy (0.9x) and GRUB 2 configurations.
 
 Bootmode defaults to "all", so settings are applied for all boot types usually.
 
-Apply only to normal boots:
+Apply only to the default boot:
+
+    kernel_parameter { "quiet":
+      ensure   => present,
+      bootmode => "default",
+    }
+
+Apply only to normal boots. In GRUB legacy, normal boots consist of the default boot plus non-recovery ones. In GRUB2, normal bootmode is just an alias for default.
 
     kernel_parameter { "quiet":
       ensure   => present,

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -27,7 +27,8 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
 
       # Params are nicely separated, but no recovery-only setting (hard-coded)
       sections = { 'all'    => "GRUB_CMDLINE_LINUX",
-                   'normal' => "GRUB_CMDLINE_LINUX_DEFAULT" }
+                   'normal' => "GRUB_CMDLINE_LINUX_DEFAULT",
+                   'default' => "GRUB_CMDLINE_LINUX_DEFAULT" }
       sections.keys.sort.each do |bootmode|
         key = sections[bootmode]
         # Get all unique param names
@@ -52,7 +53,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
 
   def self.section(resource)
     case resource[:bootmode].to_s
-    when "normal"
+    when "default", "normal"
       "GRUB_CMDLINE_LINUX_DEFAULT"
     when "all"
       "GRUB_CMDLINE_LINUX"

--- a/lib/puppet/type/kernel_parameter.rb
+++ b/lib/puppet/type/kernel_parameter.rb
@@ -22,9 +22,9 @@ Puppet::Type.newtype(:kernel_parameter) do
   end
 
   newparam(:bootmode) do
-    desc "Boot mode(s) to apply the parameter to.  Either 'all' (default) to use the parameter on all boots (normal and recovery mode), 'normal' for just normal boots or 'recovery' for just recovery boots."
+    desc "Boot mode(s) to apply the parameter to.  Either 'all' (default) to use the parameter on all boots (normal and recovery mode), 'default' for just the default boot entry, 'normal' for just normal boots or 'recovery' for just recovery boots."
 
-    newvalues :all, :normal, :recovery
+    newvalues :all, :default, :normal, :recovery
 
     defaultto :all
   end

--- a/spec/fixtures/unit/puppet/provider/kernel_parameter/grub/broken
+++ b/spec/fixtures/unit/puppet/provider/kernel_parameter/grub/broken
@@ -22,5 +22,5 @@ title Red Hat Enterprise Linux Server (2.6.18-308.13.1.el5) (recovery mode)
 	initrd /initrd-2.6.18-308.13.1.el5.img
 title Red Hat Enterprise Linux Server (2.6.18-194.el5)
 	root (hd0,0)
-	kernel /vmlinuz-2.6.18-194.el5 ro root=/dev/VolGroup00/LogVol00 rhgb quiet elevator=noop divider=10
+	kernel /vmlinuz-2.6.18-194.el5 ro root=/dev/VolGroup00/LogVol00 rhgb quiet elevator=noop divider=10 splash nohz=on
 	initrd /initrd-2.6.18-194.el5.img

--- a/spec/fixtures/unit/puppet/provider/kernel_parameter/grub/full
+++ b/spec/fixtures/unit/puppet/provider/kernel_parameter/grub/full
@@ -21,5 +21,5 @@ title Red Hat Enterprise Linux Server (2.6.18-308.13.1.el5) (recovery mode)
 	initrd /initrd-2.6.18-308.13.1.el5.img
 title Red Hat Enterprise Linux Server (2.6.18-194.el5)
 	root (hd0,0)
-	kernel /vmlinuz-2.6.18-194.el5 ro root=/dev/VolGroup00/LogVol00 rhgb quiet elevator=noop divider=10
+	kernel /vmlinuz-2.6.18-194.el5 ro root=/dev/VolGroup00/LogVol00 rhgb quiet elevator=noop divider=10 splash nohz=on
 	initrd /initrd-2.6.18-194.el5.img

--- a/spec/fixtures/unit/puppet/provider/kernel_parameter/grub2/broken
+++ b/spec/fixtures/unit/puppet/provider/kernel_parameter/grub2/broken
@@ -4,6 +4,6 @@ GRUB_DEFAULT=saved
 # GRUB_TERMINAL="serial console"
 # GRUB_SERIAL_COMMAND="serial --unit=0 --speed=9600"
 GRUB_CMDLINE_LINUX="quiet elevator=noop divider=10"
-GRUB_CMDLINE_LINUX_DEFAULT="rhgb"
+GRUB_CMDLINE_LINUX_DEFAULT="rhgb nohz=on"
 GRUB_DISABLE_RECOVERY="true"
 GRUB_THEME=/boot/grub2/themes/system/theme.txt

--- a/spec/fixtures/unit/puppet/provider/kernel_parameter/grub2/full
+++ b/spec/fixtures/unit/puppet/provider/kernel_parameter/grub2/full
@@ -4,6 +4,6 @@ GRUB_DEFAULT=saved
 # GRUB_TERMINAL="serial console"
 # GRUB_SERIAL_COMMAND="serial --unit=0 --speed=9600"
 GRUB_CMDLINE_LINUX="quiet elevator=noop divider=10"
-GRUB_CMDLINE_LINUX_DEFAULT="rhgb"
+GRUB_CMDLINE_LINUX_DEFAULT="rhgb nohz=on"
 GRUB_DISABLE_RECOVERY="true"
 GRUB_THEME=/boot/grub2/themes/system/theme.txt

--- a/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
@@ -54,11 +54,14 @@ describe provider_class do
         }
       }
 
-      inst.size.should == 4
+      inst.size.should == 7
       inst[0].should == {:name=>"quiet", :ensure=>:present, :value=>:absent, :bootmode=>"all"}
       inst[1].should == {:name=>"elevator", :ensure=>:present, :value=>"noop", :bootmode=>"all"}
       inst[2].should == {:name=>"divider", :ensure=>:present, :value=>"10", :bootmode=>"all"}
-      inst[3].should == {:name=>"rhgb", :ensure=>:present, :value=>:absent, :bootmode=>"normal"}
+      inst[3].should == {:name=>"rhgb", :ensure=>:present, :value=>:absent, :bootmode=>"default"}
+      inst[4].should == {:name=>"nohz", :ensure=>:present, :value=>"on", :bootmode=>"default"}
+      inst[5].should == {:name=>"rhgb", :ensure=>:present, :value=>:absent, :bootmode=>"normal"}
+      inst[6].should == {:name=>"nohz", :ensure=>:present, :value=>"on", :bootmode=>"normal"}
     end
 
     describe "when creating entries" do
@@ -85,6 +88,7 @@ describe provider_class do
           { "GRUB_CMDLINE_LINUX_DEFAULT"
             { "quote" = "\"" }
             { "value" = "rhgb" }
+            { "value" = "nohz=on" }
           }
         ')
       end
@@ -109,6 +113,7 @@ describe provider_class do
           { "GRUB_CMDLINE_LINUX_DEFAULT"
             { "quote" = "\"" }
             { "value" = "rhgb" }
+            { "value" = "nohz=on" }
           }
         ')
       end
@@ -134,6 +139,7 @@ describe provider_class do
           { "GRUB_CMDLINE_LINUX_DEFAULT"
             { "quote" = "\"" }
             { "value" = "rhgb" }
+            { "value" = "nohz=on" }
           }
         ')
       end
@@ -157,6 +163,32 @@ describe provider_class do
           { "GRUB_CMDLINE_LINUX_DEFAULT"
             { "quote" = "\"" }
             { "value" = "rhgb" }
+            { "value" = "nohz=on" }
+            { "value" = "foo" }
+          }
+        ')
+      end
+
+      it "should create default boot-only entries" do
+        apply!(Puppet::Type.type(:kernel_parameter).new(
+          :name     => "foo",
+          :ensure   => :present,
+          :bootmode => :default,
+          :target   => target,
+          :provider => "grub2"
+        ))
+
+        augparse_filter(target, LENS, FILTER, '
+          { "GRUB_CMDLINE_LINUX"
+            { "quote" = "\"" }
+            { "value" = "quiet" }
+            { "value" = "elevator=noop" }
+            { "value" = "divider=10" }
+          }
+          { "GRUB_CMDLINE_LINUX_DEFAULT"
+            { "quote" = "\"" }
+            { "value" = "rhgb" }
+            { "value" = "nohz=on" }
             { "value" = "foo" }
           }
         ')
@@ -196,6 +228,7 @@ describe provider_class do
         { "GRUB_CMDLINE_LINUX_DEFAULT"
           { "quote" = "\"" }
           { "value" = "rhgb" }
+          { "value" = "nohz=on" }
         }
       ')
     end
@@ -225,6 +258,7 @@ describe provider_class do
           { "GRUB_CMDLINE_LINUX_DEFAULT"
             { "quote" = "\"" }
             { "value" = "rhgb" }
+            { "value" = "nohz=on" }
           }
         ')
       end
@@ -249,6 +283,7 @@ describe provider_class do
           { "GRUB_CMDLINE_LINUX_DEFAULT"
             { "quote" = "\"" }
             { "value" = "rhgb" }
+            { "value" = "nohz=on" }
           }
         ')
       end
@@ -276,6 +311,7 @@ describe provider_class do
           { "GRUB_CMDLINE_LINUX_DEFAULT"
             { "quote" = "\"" }
             { "value" = "rhgb" }
+            { "value" = "nohz=on" }
           }
         ')
 
@@ -298,6 +334,7 @@ describe provider_class do
           { "GRUB_CMDLINE_LINUX_DEFAULT"
             { "quote" = "\"" }
             { "value" = "rhgb" }
+            { "value" = "nohz=on" }
           }
         ')
       end

--- a/spec/unit/puppet/provider/kernel_parameter/grub_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub_spec.rb
@@ -39,15 +39,17 @@ describe provider_class do
         }
       }
 
-      inst.size.should == 8
+      inst.size.should == 10
       inst[0].should == {:name=>"ro", :ensure=>:present, :value=>:absent, :bootmode=>:all}
       inst[1].should == {:name=>"root", :ensure=>:present, :value=>"/dev/VolGroup00/LogVol00", :bootmode=>:all}
-      inst[2].should == {:name=>"rhgb", :ensure=>:present, :value=>:absent, :bootmode=>:normal}
-      inst[3].should == {:name=>"quiet", :ensure=>:present, :value=>:absent, :bootmode=>:normal}
+      inst[2].should == {:name=>"rhgb", :ensure=>:present, :value=>:absent, :bootmode=>:default}
+      inst[3].should == {:name=>"quiet", :ensure=>:present, :value=>:absent, :bootmode=>:default}
       inst[4].should == {:name=>"elevator", :ensure=>:present, :value=>"noop", :bootmode=>:all}
       inst[5].should == {:name=>"divider", :ensure=>:present, :value=>"10", :bootmode=>:all}
-      inst[6].should == {:name=>"rd_LVM_LV", :ensure=>:present, :value=>["vg/lv1", "vg/lv2"], :bootmode=>:normal}
+      inst[6].should == {:name=>"rd_LVM_LV", :ensure=>:present, :value=>["vg/lv1", "vg/lv2"], :bootmode=>:default}
       inst[7].should == {:name=>"S", :ensure=>:present, :value=>:absent, :bootmode=>:recovery}
+      inst[8].should == {:name=>"splash", :ensure=>:present, :value=>:absent, :bootmode=>:normal}
+      inst[9].should == {:name=>"nohz", :ensure=>:present, :value=>"on", :bootmode=>:normal}
     end
 
     describe "when creating entries" do
@@ -128,6 +130,21 @@ describe provider_class do
           aug.match("title/kernel/rd_LVM_LV[.='vg/lv1']").size.should == 0
           aug.match("title/kernel/rd_LVM_LV[.='vg/lv2']").size.should == 0
           aug.match("title/kernel/rd_LVM_LV").map {|p| aug.get(p)}.should == ["vg/lv7"]*3
+        end
+      end
+
+      it "should create default-only entries" do
+        apply!(Puppet::Type.type(:kernel_parameter).new(
+          :name     => "foo",
+          :ensure   => :present,
+          :bootmode => :default,
+          :target   => target,
+          :provider => "grub"
+        ))
+
+        aug_open(target, "Grub.lns") do |aug|
+          aug.match("title/kernel/foo").size.should == 1
+          aug.match("title[int(../default)+1]/kernel/foo").size.should == 1
         end
       end
 


### PR DESCRIPTION
When bootmode is default, only the boot entry set as default will be considered when applying changes.

There was also an old post at https://www.redhat.com/archives/augeas-devel/2013-May/msg00006.html asking how to achieve this.