### PR TITLE
Fix GRUB_CMDLINE_LINUX_DEFAULT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,15 @@ spec/fixtures/modules
 yardoc/
 .yardoc/
 
+## Beaker
+.vagrant
+log
+
 ## Ruby
 .rvmrc*
 .rbenv*
 .ruby-*
+Gemfile.lock
 
 ## MAC OS
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,12 @@ group :development, :unit_tests do
   gem 'yard',                                              :require => false
   gem 'redcarpet', '~> 2.0',                               :require => false
 end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
+  gem 'simp-beaker-helpers'
+end

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -75,8 +75,43 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
     end
   end
 
+  # If GRUB_CMDLINE_LINUX_DEFAULT does not exist, it should be set to the
+  # present contents of GRUB_CMDLINE_LINUX.
+  # If this is not done, you may end up with garbage on your next kernel
+  # upgrade!
+  def munge_grub_cmdline_linux_default(aug)
+    src_path = '$target/GRUB_CMDLINE_LINUX/value'
+    dest_path = '$target/GRUB_CMDLINE_LINUX_DEFAULT'
+
+    if aug.match("#{dest_path}/value").empty?
+      aug.match(src_path).each do |val|
+        src_val = aug.get(val)
+
+       # Need to let the rest of the code work on the actual value properly.
+       unless src_val.split('=').first.strip == resource[:name]
+          val_target = val.split('/').last
+
+          aug.set("#{dest_path}/#{val_target}", src_val)
+        end
+      end
+    end
+  end
+
   def value=(newval)
     augopen! do |aug|
+      # If we don't have the section at all, add it. Otherwise, any
+      # manipulation will result in a parse error.
+      current_section = self.class.section(resource)
+      has_section = aug.match("$target/#{current_section}")
+
+      if !has_section || has_section.empty?
+        aug.set("$target/#{current_section}/quote",'"')
+      end
+
+      if current_section == 'GRUB_CMDLINE_LINUX_DEFAULT'
+       munge_grub_cmdline_linux_default(aug)
+      end
+
       if newval && !newval.empty?
         vals = newval.clone
       else
@@ -102,7 +137,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
       # Add new parameters where there are more values than existing params
       if vals && !vals.empty?
         vals.each do |val|
-          aug.set("$target/#{self.class.section(resource)}/value[last()+1]", "#{resource[:name]}=#{val}")
+          aug.set("$target/#{current_section}/value[last()+1]", "#{resource[:name]}=#{val}")
         end
       end
     end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper_acceptance'
+
+test_name 'Augeasproviders Grub'
+
+describe 'Grub Tests' do
+  tests = {
+    :basic => {
+      :manifest => %(
+        kernel_parameter { 'audit':
+          value    => '1'
+        }),
+      :test => %(grep "audit=1" /proc/cmdline)
+    },
+    :normal_bootmode => {
+      :manifest => %(
+        kernel_parameter { 'audit':
+          value    => '1',
+          bootmode => 'normal'
+        }),
+      :test => %(grep "audit=1" /proc/cmdline)
+    }
+  }
+
+  tests.keys.each do |key|
+    let(:manifest){ tests[key][:manifest] }
+    let(:test){ tests[key][:test] }
+
+    context "default parameters for #{key}" do
+      hosts.each do |host|
+        # Using puppet_apply as a helper
+        it 'should work with no errors' do
+          apply_manifest_on(host, manifest, :catch_failures => true)
+        end
+    
+        it 'should be idempotent' do
+          apply_manifest_on(host, manifest, {:catch_changes => true})
+        end
+    
+        it 'is expected to have auditing enabled at boot time' do
+          host.reboot
+          on(host, test)
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,23 @@
+HOSTS:
+  server:
+    roles:
+      - server
+      - default
+      - master
+    platform:   el-7-x86_64
+    box:        puppetlabs/centos-7.0-64-nocm
+    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    hypervisor: vagrant
+  client:
+    roles:
+      - agent
+      - client
+    platform:   el-6-x86_64
+    box:        puppetlabs/centos-6.6-64-nocm
+    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: verbose
+  type:      foss
+  vagrant_memsize: 256
+  ## vb_gui: true

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,34 @@
+require 'beaker-rspec'
+require 'tmpdir'
+require 'yaml'
+
+# Force FIPS off for these tests since it is not relevant.
+ENV['BEAKER_fips'] = 'no'
+
+require 'simp/beaker_helpers'
+include Simp::BeakerHelpers
+
+unless ENV['BEAKER_provision'] == 'no'
+  hosts.each do |host|
+    # Install Puppet
+    if host.is_pe?
+      install_pe
+    else
+      install_puppet
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include Helpers
+
+  # ensure that environment OS is ready on each host
+  fix_errata_on hosts
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  c.before :suite do
+    copy_fixture_modules_to( hosts )
+  end
+end


### PR DESCRIPTION
* Ensure that any missing element is created before attemping to be
  modified. This prevents Augeas failures.

* Copy GRUB_CMDLINE_LINUX to GRUB_CMDLINE_LINUX_DEFAULT if the latter
  does not exist.

* Added Beaker tests to cover these two cases and allow for further
  practical expansion.

Fixes hercules-team/augeasproviders_grub#11