### PR TITLE
add grub.cfg location for grub2 on UEFI systems

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -110,7 +110,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
 
   def flush
     cfg = nil
-    ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"].each {|c|
+    ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg", "/boot/efi/EFI/fedora/grub.cfg"].each {|c|
       cfg = c if FileTest.file? c
     }
     fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg


### PR DESCRIPTION
on UEFI systems, grub.cfg will be located at:

/boot/efi/EFI/fedora/grub.cfg

And you'll end up with this error:

```
Warning: Found multiple default providers for kernel_parameter: grub2, grub; using grub2
Error: /Stage[main]/Profiles::Grub/Kernel_parameter[elevator]: Could not evaluate: Augeas didn't load /boot/efi/EFI/fedora/grub.cfg with Shellvars_list.lns: Iterated lens matched less than it should (line:9, character:3)
```

This adds the UEFI grub.cfg location as per https://docs.fedoraproject.org/en-US/Fedora/23/html/Multiboot_Guide/GRUB-configuration.html