### PR TITLE
adding 2 defaults for grub 2

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -19,6 +19,9 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
   end
 
   defaultfor :osfamily => 'Redhat', :operatingsystemmajrelease => [ '7' ]
+  defaultfor :operatingsystem => 'Debian', :operatingsystemmajrelease => [ '8' ]
+  defaultfor :operatingsystem => 'Ubuntu', :operatingsystemmajrelease => [ '14.04' ]
+
   confine :feature => :augeas
   commands :mkconfig => mkconfig_path
 


### PR DESCRIPTION
Hi,

A small change to avoid the following message on my Debian 8:
Warning: Found multiple default providers for kernel_parameter: grub2, grub; using grub2

I also made a change for the issue #13

Tested on CentOS 7 and Debian 8