### PR TITLE
Added support for global GRUB configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
+  gem 'vagrant-wrapper'
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'

--- a/lib/puppet/provider/grub_config/grub.rb
+++ b/lib/puppet/provider/grub_config/grub.rb
@@ -1,0 +1,75 @@
+# GRUB legacy / 0.9x support for kernel parameters
+#
+# Copyright (c) 2016 Trevor Vaughan <tvaughan@onyxpoint.com>
+# Licensed under the Apache License, Version 2.0
+# Based on work by Dominic Cleal
+
+Puppet::Type.type(:grub_config).provide(:grub, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
+  desc "Uses Augeas API to update kernel parameters in GRUB's menu.lst"
+
+  default_file do
+    FileTest.exist?("/boot/efi/EFI/redhat/grub.conf") ? "/boot/efi/EFI/redhat/grub.conf" : "/boot/grub/menu.lst"
+  end
+
+  lens { 'Grub.lns' }
+
+  confine :feature => :augeas
+  commands :grub => 'grub'
+
+  def self.instances
+    augopen do |aug|
+      resources = []
+      # Get all global configuration items
+      # Skip 'title' segments since this provider should not manage them.
+      params = aug.match("$target/*").delete_if{|pp| pp =~ %r((#comment|/title$)) }
+
+      params.each do |pp|
+        # Then retrieve all unique values as string (1) or array
+        val = aug.get(pp)
+        param = pp.split('/').last
+
+        resource = {:ensure => :present, :name => param}
+
+        if val
+          val = val[0] if val.size == 1
+          resource[:value] = val
+        end
+
+        resources << new(resource)
+      end
+
+      resources
+    end
+  end
+
+  def exists?
+    augopen do |aug|
+      !aug.match("$target/#{resource[:name]}").empty?
+    end
+  end
+
+  def create
+    augopen! do |aug|
+      aug.insert('$target/title[1]',resource[:name],true)
+      aug.set("$target/#{resource[:name]}", resource[:value])
+    end
+  end
+
+  def destroy
+    augopen! do |aug|
+      aug.rm("$target/#{resource[:name]}")
+    end
+  end
+
+  def value
+    augopen do |aug|
+      aug.get("$target/#{resource[:name]}")
+    end
+  end
+
+  def value=(newval)
+    augopen! do |aug|
+      aug.set("$target/#{resource[:name]}", newval)
+    end
+  end
+end

--- a/lib/puppet/provider/grub_config/grub2.rb
+++ b/lib/puppet/provider/grub_config/grub2.rb
@@ -1,0 +1,83 @@
+# GRUB 2 support for kernel parameters, edits /etc/default/grub
+#
+# Copyright (c) 2016 Trevor Vaughan <tvaughan@onyxpoint.com>
+# Licensed under the Apache License, Version 2.0
+# Based on work by Dominic Cleal
+
+Puppet::Type.type(:grub_config).provide(:grub2, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
+  desc "Uses Augeas API to update kernel parameters in GRUB2's /etc/default/grub"
+
+  default_file { '/etc/default/grub' }
+
+  lens { 'Shellvars.lns' }
+
+  def self.mkconfig_path
+    which("grub2-mkconfig") or which("grub-mkconfig") or '/usr/sbin/grub-mkconfig'
+  end
+
+  confine :feature => :augeas
+  commands :mkconfig => mkconfig_path
+
+  defaultfor :osfamily => :RedHat
+
+  def self.instances
+    augopen do |aug|
+      resources = []
+
+      aug.match('$target/*').each do |key|
+        param = key.split('/').last.strip
+        val = aug.get(key)
+
+        resource = {:ensure => :present, :name => param}
+
+        if val
+          val.strip!
+          resource[:value] = val
+        end
+
+        resources << new(resource)
+      end
+
+      resources
+    end
+  end
+
+  def exists?
+    augopen do |aug|
+      !aug.match("$target/#{resource[:name]}").empty?
+    end
+  end
+
+  def create
+    self.value=(resource[:value])
+  end
+
+  def destroy
+    augopen! do |aug|
+      aug.rm("$target/#{resource[:name]}")
+    end
+  end
+
+  def value
+    augopen do |aug|
+      aug.get("$target/#{resource[:name]}")
+    end
+  end
+
+  def value=(newval)
+    augopen! do |aug|
+      aug.set("$target/#{resource[:name]}", newval)
+    end
+  end
+
+  def flush
+    cfg = nil
+    ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"].each {|c|
+      cfg = c if FileTest.file? c
+    }
+    fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg
+
+    super
+    mkconfig "-o", cfg
+  end
+end

--- a/lib/puppet/provider/grub_menuentry/grub.rb
+++ b/lib/puppet/provider/grub_menuentry/grub.rb
@@ -1,0 +1,482 @@
+# GRUB legacy / 0.9x support for menu entries
+#
+# Copyright (c) 2016 Trevor Vaughan <tvaughan@onyxpoint.com>
+# Licensed under the Apache License, Version 2.0
+# Based on work by Dominic Cleal
+
+Puppet::Type.type(:grub_menuentry).provide(:grub, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
+  desc "Uses Augeas API to update GRUB menu entries"
+
+  has_feature :grub
+
+  default_file do
+    FileTest.exist?("/boot/efi/EFI/redhat/grub.conf") ? "/boot/efi/EFI/redhat/grub.conf" : "/boot/grub/menu.lst"
+  end
+
+  lens { 'Grub.lns' }
+
+  confine :feature => :augeas
+  commands :grub => 'grub'
+  commands :grubby => 'grubby'
+
+  #### Class Methods
+
+  #Pull the kernel options off of the system and arrange them properly
+  # into the Array of Arrays.
+  #
+  # @param aug (Augeas) the Augeas tree object
+  # @param path (String) the root entry path
+  def self.get_kernel_options(aug, path)
+    kernel_options = []
+
+    aug.match("#{path}/kernel/*").each do |kopt|
+      kopt_val = aug.get(kopt)
+      kopt = kopt.split('/').last.split('[').first
+
+      if kopt_val
+        kernel_options << "#{kopt}=#{kopt_val}"
+      else
+        kernel_options << kopt
+      end
+    end
+
+    kernel_options
+  end
+
+  # Retrieve the list of modules from the GRUB menu entry.
+  #
+  # @param aug (Augeas) the Augeas tree object
+  # @param path (String) the root entry path
+  def self.get_modules(aug, path)
+    modules = []
+
+    if aug.exists("#{path}/module[1]")
+
+      file_modules = aug.match("#{path}/module")
+      file_modules.each do |file_mod|
+        # Modules have a full path
+        mod_name = "/#{aug.get(file_mod).split('/').last}"
+
+        new_mod = [mod_name]
+
+        aug.match("#{file_mod}/*").each do |mod_opt|
+          mod_opt_val = aug.get(mod_opt)
+          mod_opt = mod_opt.split('/').last.split('[').first
+
+          if mod_opt_val
+            new_mod << "#{mod_opt}=#{mod_opt_val}"
+          else
+            new_mod << mod_opt
+          end
+        end
+
+        modules << new_mod
+      end
+    end
+
+    modules
+  end
+
+  def self.instances
+    require 'puppetx/augeasproviders_grub/menuentry'
+
+    resources = []
+
+    augopen do |aug|
+      menu_entries = aug.match("$target/title")
+
+      menu_entries.each do |pp|
+        # Then retrieve all unique values as string (1) or array
+        entry_name = aug.get(pp)
+        kernel = aug.get("#{pp}/kernel")
+        initrd = aug.get("#{pp}/initrd")
+        fs_root = aug.get("#{pp}/root")
+        default_entry = ((aug.get("$target/default") || '0').to_i + 1).to_s.to_sym
+
+        modules = self.class.get_modules(aug, pp)
+
+        resource = {
+          :name          => entry_name,
+          :ensure        => :present,
+          :root          => fs_root,
+          :default_entry => (pp.split('[').last[0].chr == default_entry).to_s.to_sym,
+          # Broken in the lens
+          #:lock          => aug.exists("#{pp}/lock").to_s.to_sym,
+          :makeactive    => aug.exists("#{pp}/makeactive").to_s.to_sym
+        }
+
+        if kernel
+          resource[:kernel] = kernel
+
+          kernel_options = self.class.get_kernel_options(aug, pp)
+
+          if kernel_options && !kernel_options.empty?
+            resource[:kernel_options] = kernel_options
+          end
+        end
+
+        if initrd
+          resource[:initrd] = initrd
+        end
+
+        if modules && !modules.empty?
+          resource[:modules] = modules
+        end
+
+        resources << new(resource)
+      end
+    end
+
+    resources
+  end
+  #### End Class Methods
+
+
+  def initialize(*args)
+    require 'puppetx/augeasproviders_grub/menuentry'
+
+    @grubby_info = {}
+    begin
+      grubby_raw = grubby '--info=DEFAULT'
+
+      grubby_raw.each_line do |opt|
+        key,val = opt.split('=')
+
+        @grubby_info[key.strip] = val.strip
+      end
+    rescue PuppetExecutionFailure
+      @grubby_info = {}
+    end
+
+    # Accelerators to reduce code complexity
+    @new_kernel_options = []
+    @new_modules_options = []
+
+    super(*args)
+
+    # We need to record these here in case they get changed in the future.
+    augopen do |aug|
+      default_entry_index = ((aug.get("$target/default") || '0').to_i + 1).to_s
+      default_entry_path  = %($target/title[#{default_entry_index}])
+
+      @default_entry = {
+        :path           => default_entry_path,
+        :index          => default_entry_index,
+        :kernel_options => self.class.get_kernel_options(aug, default_entry_path),
+        :kernel         => @grubby_info['kernel'],
+        :initrd         => @grubby_info['initrd']
+      }
+    end
+  end
+
+  def exists?
+    augopen do |aug|
+      !aug.match(menu_entry_path).empty?
+    end
+  end
+
+  def create
+    # Input Validation
+    fail Puppet::Error, '`kernel` is a required property' unless resource[:kernel]
+    fail Puppet::Error, '`root` is a required property' unless resource[:root]
+
+    unless resource[:modules]
+      fail Puppet::Error, '`initrd` is a required parameter' unless resource[:initrd]
+    end
+
+    augopen! do |aug|
+      aug.insert('$target/title[1]','title',true)
+      aug.set('$target/title[1]',resource[:name])
+    end
+
+    # Order matters!
+    self.root=(resource[:root])
+
+    # Need to prime this to reduce duplication later
+    self.kernel?([],resource[:kernel])
+    self.kernel=(resource[:kernel])
+
+    if resource[:kernel_options]
+      # Need to prime this to reduce duplication later
+      self.kernel_options?([],resource[:kernel_options])
+      self.kernel_options=(resource[:kernel_options])
+    end
+
+    if resource[:initrd]
+      # Need to prime this to reduce duplication later
+      self.initrd?([],resource[:initrd])
+      self.initrd=(resource[:initrd])
+    end
+
+    if resource[:modules]
+      # Need to prime this to reduce duplication later
+      self.modules?([],resource[:modules])
+      self.modules=(resource[:modules])
+    end
+
+    # Broken in the lens
+    #self.lock=(resource[:lock])
+    if resource[:makeactive]
+      self.makeactive=(resource[:makeactive])
+    end
+
+    if resource[:default_entry]
+      self.default_entry=(resource[:default_entry])
+    end
+  end
+
+  def destroy
+    augopen! do |aug|
+      aug.rm(menu_entry_path)
+    end
+  end
+
+  def root
+    augopen do |aug|
+      aug.get("#{menu_entry_path}/root")
+    end
+  end
+
+  def root?(is,should)
+    is == should
+  end
+
+  def root=(newval)
+    augopen! do |aug|
+      aug.set("#{menu_entry_path}/root", newval)
+    end
+  end
+
+  def default_entry
+    return (menu_entry_index == @default_entry[:index]).to_s.to_sym
+  end
+
+  def default_entry=(newval)
+    augopen! do |aug|
+      aug.set('$target/default', (menu_entry_index.to_i - 1).to_s)
+    end
+  end
+
+  def initrd
+    augopen do |aug|
+      aug.get("#{menu_entry_path}/initrd")
+    end
+  end
+
+  def initrd?(is,should)
+    return true unless should
+
+    @new_initrd = should
+
+    if @new_initrd == ':preserve:'
+      @new_initrd = is
+      if !@new_initrd || @new_initrd.empty?
+        @new_initrd = ':default:'
+      end
+    end
+
+    if @new_initrd == ':default:'
+      @new_initrd = PuppetX::AugeasprovidersGrub::Util.munge_grubby_value(@new_initrd, 'initrd', @grubby_info)
+    end
+
+    unless @new_initrd
+      raise Puppet::Error, 'Could not find a valid initrd value to set'
+    end
+
+    is == @new_initrd
+  end
+
+  def initrd=(newval)
+    augopen! do |aug|
+      aug.set("#{menu_entry_path}/initrd",PuppetX::AugeasprovidersGrub::Util.munge_grubby_value(@new_initrd,'initrd',@grubby_info))
+    end
+  end
+
+  def kernel
+    augopen do |aug|
+      aug.get("#{menu_entry_path}/kernel")
+    end
+  end
+
+  def kernel?(is,should)
+    return true unless should
+
+    @new_kernel = should
+
+    if @new_kernel == ':preserve:'
+      @new_kernel = is
+      if !@new_kernel || @new_kernel.empty?
+        @new_kernel = ':default:'
+      end
+    end
+
+    if @new_kernel == ':default:'
+      @new_kernel = PuppetX::AugeasprovidersGrub::Util.munge_grubby_value(@new_kernel, 'kernel', @grubby_info)
+    end
+
+    unless @new_kernel
+      raise Puppet::Error, 'Could not find a valid kernel value to set'
+    end
+
+    is == @new_kernel
+  end
+
+  def kernel=(newval)
+    augopen! do |aug|
+      aug.set("#{menu_entry_path}/kernel",@new_kernel)
+    end
+  end
+
+  def kernel_options
+    augopen do |aug|
+      self.class.get_kernel_options(aug, menu_entry_path)
+    end
+  end
+
+  def kernel_options?(is,should)
+    if resource[:add_defaults_on_creation] == :true && should.include?(':preserve:')
+      should << ':defaults:'
+    end
+
+    default_kernel_options = @default_entry[:kernel_options]
+    if resource[:modules]
+      # We don't want to pick up any default kernel options if this is a multiboot entry.
+      default_kernel_options = {}
+    end
+
+    @new_kernel_options = PuppetX::AugeasprovidersGrub::Util.munged_options(is, should, @default_entry[:kernel], default_kernel_options)
+    old_options = PuppetX::AugeasprovidersGrub::Util.munged_options(is, ':preserve:', @default_entry[:kernel], @default_entry[:kernel_options])
+
+    old_options == @new_kernel_options
+  end
+
+  def kernel_options=(newval)
+    new_kernel_options = @new_kernel_options
+
+    default_kernel_options = @default_entry[:kernel_options]
+    if resource[:modules]
+      # We don't want to pick up any default kernel options if this is a multiboot entry.
+      default_kernel_options = {}
+    end
+
+    if Array(new_kernel_options).empty?
+      new_kernel_options = PuppetX::AugeasprovidersGrub::Util.munged_options([], newval, @default_entry[:kernel], default_kernel_options)
+    end
+
+    process_option_line(new_kernel_options,'kernel')
+  end
+
+  def lock
+    augopen do |aug|
+      return aug.exists("#{menu_entry_path}/lock").to_s.to_sym
+    end
+  end
+
+  def modules
+    augopen do |aug|
+      self.class.get_modules(aug, menu_entry_path)
+    end
+  end
+
+  def modules?(is,should)
+    @new_modules_options = []
+    old_options = []
+
+    i = 0
+    Array(should).each do |module_set|
+      if resource[:add_defaults_on_creation] == :true && module_set.include?(':preserve:')
+        module_set << ':defaults:'
+      end
+
+      current_val = Array(Array(is)[i])
+      @new_modules_options << PuppetX::AugeasprovidersGrub::Util.munged_options(current_val, module_set, @default_entry[:kernel], @default_entry[:kernel_options], true)
+
+      unless current_val.empty?
+        old_options << PuppetX::AugeasprovidersGrub::Util.munged_options(current_val,':preserve:', @default_entry[:kernel], @default_entry[:kernel_options], true)
+      end
+
+      i += 1
+    end
+
+    return old_options == @new_modules_options
+  end
+
+  def modules=(newval)
+    new_modules_options = @new_modules_options
+
+    if Array(new_modules_options).empty?
+      new_modules_options = []
+      Array(newval).each do |module_set|
+        new_modules_options << PuppetX::AugeasprovidersGrub::Util.munged_options([], module_set, @default_entry[:kernel], @default_entry[:kernel_options])
+      end
+    end
+
+    process_option_line(new_modules_options,'module')
+  end
+
+  def lock=(newval)
+    augopen! do |aug|
+      if newval == :true
+        aug.set("#{menu_entry_path}/lock")
+      else
+        aug.rm("#{menu_entry_path}/lock")
+      end
+    end
+  end
+
+  def makeactive
+    augopen do |aug|
+      return aug.exists("#{menu_entry_path}/makeactive").to_s.to_sym
+    end
+  end
+
+  def makeactive=(newval)
+    augopen! do |aug|
+      if newval == :true
+        aug.set("#{menu_entry_path}/makeactive")
+      else
+        aug.rm("#{menu_entry_path}/makeactive")
+      end
+    end
+  end
+
+  # Helper Methods
+  private
+  # Handles 'kernel'-style option lines
+  # Probably not foolproof...
+  def process_option_line(newval, flavor)
+    augopen! do |aug|
+      # Get rid of all of them and rewrite them
+      if flavor == 'kernel'
+        aug.rm("#{menu_entry_path}/#{flavor}/*")
+      else
+        aug.rm("#{menu_entry_path}/#{flavor}")
+      end
+
+      Array(newval).each do |opt_array|
+        # Module sections are relatively arbitrary and can have multiple
+        # entries.
+        unless flavor == 'kernel'
+          opt_name = Array(opt_array).shift
+          aug.set("#{menu_entry_path}/#{flavor}[last()+1]", opt_name)
+        end
+
+        Array(opt_array).each do |base_opts|
+          opt,val = base_opts.split('=')
+
+          aug.set("#{menu_entry_path}/#{flavor}[last()]/#{opt}[last()+1]",val)
+        end
+      end
+    end
+  end
+
+  def menu_entry_path
+    return %($target/title[. = "#{resource[:name]}"])
+  end
+
+  def menu_entry_index
+    augopen do |aug|
+      return aug.match(menu_entry_path).first.split('[').last.chop
+    end
+  end
+end

--- a/lib/puppet/provider/grub_menuentry/grub2.rb
+++ b/lib/puppet/provider/grub_menuentry/grub2.rb
@@ -1,0 +1,553 @@
+# GRUB 2 support for menuentries, adds material to /etc/grub.d/05_puppet_controlled_*
+#
+# Copyright (c) 2016 Trevor Vaughan <tvaughan@onyxpoint.com>
+# Licensed under the Apache License, Version 2.0
+
+Puppet::Type.type(:grub_menuentry).provide(:grub2) do
+  desc "Provides for the manipulation of GRUB2 menuentries"
+
+  has_feature :grub2
+
+  #### Class Methods
+  def self.mkconfig_path
+    which("grub2-mkconfig") or which("grub-mkconfig") or '/usr/sbin/grub-mkconfig'
+  end
+
+  # Return an Array of system resources culled from a full GRUB2
+  # configuration
+  #
+  # @param config (String) The output of grub2-mkconfig or the grub2.cfg file
+  # @param current_default (String) The name of the current default GRUB entry
+  # @return (Array) An Array of resource Hashes
+  def self.grub2_menuentries(config, current_default)
+    resources = []
+
+    # Pull out the menuentries into our resources
+    in_menuentry = false
+
+    # We need to track these to set the default entry
+    submenus = []
+    resource = {}
+    config.to_s.each_line do |line|
+      if line =~ /^\s*submenu (?:'|")(.*)(?:':")\s*\{/
+        submenus << $1
+      end
+
+      # The main menuentry line
+      if line =~ /^\s*menuentry '(.+?)'/
+        resource = {
+          :name => $1
+        }
+
+        if resource[:name] == current_default
+          resource[:default_entry] = true
+        else
+          resource[:default_entry] = false
+        end
+
+        if in_menuentry
+          raise Puppet::Error, "Malformed config file received"
+        end
+
+        in_menuentry = true
+
+        menuentry_components = line.strip.split(/\s+/)[1..-1]
+
+        classes = []
+        menuentry_components.each_index do |i|
+          if menuentry_components[i] == '--class'
+            classes << menuentry_components[i+1]
+          end
+        end
+
+        resource[:classes] = classes unless classes.empty?
+
+        users = []
+        if menuentry_components.include?('--unrestricted')
+          users = [:unrestricted]
+        else
+          menuentry_components.each_index do |i|
+            if menuentry_components[i] == '--users'
+              # This insanity per the GRUB2 user's guide
+              users = menuentry_components[i+1].strip.split(/\s|,|;|\||&/)
+            end
+          end
+        end
+
+        resource[:users] = users unless users.empty?
+
+        resource[:load_video]     = false
+        resource[:load_16bit]     = false
+        resource[:puppet_managed] = false
+        resource[:modules] ||= []
+
+      elsif in_menuentry
+        if line =~ /^\s*load_video\s*$/
+          resource[:load_video] = true
+
+        elsif line =~ /^\s*insmod\s+(\S+)$/
+          resource[:plugins] ||= []
+
+          resource[:plugins] << $1.strip
+
+        elsif line =~ /^\s*(?:set\s+)?root='(.+)'$/
+          resource[:root] = $1.strip
+
+        elsif line =~ /^\s*#### PUPPET MANAGED ####\s*$/
+          resource[:puppet_managed] = true
+
+        elsif line =~ /^\s*(?:multiboot|linux(16)?)(.+)/
+          if $1 == '16'
+            resource[:load_16bit] = true
+          end
+
+          kernel_line = $2.strip.split(/\s+/)
+          resource[:kernel] = kernel_line.shift
+          resource[:kernel_options] = kernel_line
+
+        elsif line =~ /^\s*initrd(?:16)?(.+)/
+          resource[:initrd] = $1.strip
+
+        elsif line =~ /^\s*module\s+(.+)/
+          resource[:modules] << $1.strip.split(/\s+/)
+
+        elsif line =~ /^\s*\}\s*$/
+          in_menuentry = false
+          if resource.empty?
+            debug("Warning: menuentry resource was empty")
+          else
+            resource[:submenus] = submenus
+            resources << resource
+          end
+
+          submenus = []
+        end
+      end
+    end
+
+    return resources
+  end
+
+  def self.instances
+    require 'puppetx/augeasproviders_grub/menuentry'
+
+    if (grubby '--info=DEFAULT') =~ /^\s*title=(.+)\s*$/
+      current_default = ($2.to_i - 1)
+    end
+
+    grub2_menuentries(PuppetX::AugeasprovidersGrub::Util.grub2_cfg, current_default).map{|x| x = new(x)}
+  end
+  #### End Class Methods
+
+  commands :mkconfig => mkconfig_path
+  commands :grubby => 'grubby'
+  commands :grub_set_default => 'grub2-set-default'
+
+  confine :exists => '/etc/grub.d'
+
+  defaultfor :osfamily => :RedHat
+
+  def initialize(*args)
+    super(*args)
+
+    require 'puppetx/augeasproviders_grub/menuentry'
+
+    @grubby_info = {}
+    begin
+      grubby_raw = grubby '--info=DEFAULT'
+
+      grubby_raw.each_line do |opt|
+        key,val = opt.to_s.split('=')
+
+        @grubby_info[key.strip] = val.strip
+      end
+    rescue Puppet::ExecutionFailure
+      @grubby_info = {}
+    end
+
+    if @grubby_info['title']
+      current_default = (@grubby_info['title'])
+    end
+
+    # Things that we really only want to do once...
+    @menu_entries = self.class.grub2_menuentries(PuppetX::AugeasprovidersGrub::Util.grub2_cfg, current_default)
+
+    current_index = @menu_entries.index { |x| x[:name] == self.name }
+
+    if current_index
+      @current_entry = @menu_entries[current_index]
+    else
+      @current_entry = {}
+    end
+
+    # These only matter if we're trying to manipulate a resource
+
+    # Extract the default entry for reference later
+    @default_entry = @menu_entries.select{|x| x[:default_entry] }.first
+    raise(Puppet::Error, "Could not find a default GRUB2 entry. Check your system grub configuration using `grubby --info=DEFAULT`") unless @default_entry
+
+    require 'openssl'
+    random_file_ext = OpenSSL::Digest::SHA256.new.digest(self.name).unpack('H*').first.upcase[0..11]
+    @new_entry = @current_entry.dup
+
+    @new_entry[:name] = self.name
+    @new_entry[:output_file] = "/etc/grub.d/05_puppet_managed_#{random_file_ext}"
+  end
+
+  def exists?
+    @new_entry[:load_16bit] = (resource[:load_16bit] == :true)
+    @new_entry[:add_defaults_on_creation] = (resource[:add_defaults_on_creation] == :true)
+
+    !@current_entry.empty?
+  end
+
+  def create
+    # Input Validation
+    fail Puppet::Error, '`kernel` is a required property' unless resource[:kernel]
+    fail Puppet::Error, '`root` is a required property' unless resource[:root]
+
+    unless resource[:modules]
+      fail Puppet::Error, '`initrd` is a required parameter' unless resource[:initrd]
+    end
+    # End Validation
+
+    @new_entry[:create_output] = true
+
+    self.root=(resource[:root])
+
+    # Need to prime this to reduce duplication later
+    self.kernel?([],resource[:kernel])
+    self.kernel=(resource[:kernel])
+
+    if resource[:users]
+      self.users=(resource[:users])
+    end
+
+    if resource[:classes]
+      self.classes=(resource[:classes])
+    end
+
+    if resource[:load_video]
+      self.load_video=(resource[:load_video])
+    end
+
+    if resource[:plugins]
+      self.plugins=(resource[:plugins])
+    end
+
+    # Need to prime this to reduce duplication later
+    self.initrd?([],resource[:initrd])
+    self.initrd=(resource[:initrd])
+
+    if resource[:kernel_options]
+      # Need to prime this to reduce duplication later
+      self.kernel_options?([],resource[:kernel_options])
+      self.kernel_options=(resource[:kernel_options])
+    end
+
+    if resource[:modules]
+      # Need to prime this to reduce duplication later
+      self.modules?([],resource[:modules])
+      self.modules=(resource[:modules])
+    end
+
+    if resource[:default_entry]
+      self.default_entry=(resource[:default_entry])
+    end
+  end
+
+  def destroy
+    if File.exist?(@new_entry[:output_file])
+      FileUtils.rm_f(@new_entry[:output_file])
+    end
+  end
+
+  def classes
+    @current_entry[:classes]
+  end
+
+  def classes=(newval)
+    @new_entry[:classes] = newval
+  end
+
+  def users
+    if @current_entry[:users]
+      Array(Array(@current_entry[:users]).join(','))
+    end
+  end
+
+  def users=(newval)
+    @new_entry[:users] = newval
+  end
+
+  def load_video
+    @current_entry[:load_video].to_s.to_sym
+  end
+
+  def load_video=(newval)
+    @new_entry[:load_video] = (newval == :true)
+  end
+
+  def plugins
+    @current_entry[:plugins]
+  end
+
+  def plugins=(newval)
+    @new_entry[:plugins] = newval
+  end
+
+  def default_entry
+    @current_entry[:default_entry].to_s.to_sym
+  end
+
+  def default_entry=(newval)
+    @new_entry[:default_entry] = (newval.to_s == 'true')
+  end
+
+  def root
+    @current_entry[:root]
+  end
+
+  def root=(newval)
+    @new_entry[:root] = newval
+  end
+
+  def kernel
+    @current_entry[:kernel]
+  end
+
+  def kernel?(is,should)
+    return true unless should
+
+    @new_kernel = should
+
+    if @new_kernel == ':preserve:'
+      @new_kernel = is
+      if !@new_kernel || @new_kernel.empty?
+        @new_kernel = ':default:'
+      end
+    end
+
+    if @new_kernel == ':default:'
+      @new_kernel = PuppetX::AugeasprovidersGrub::Util.munge_grubby_value(@new_kernel, 'kernel', @grubby_info)
+    end
+
+    unless @new_kernel
+      raise Puppet::Error, 'Could not find a valid kernel value to set'
+    end
+
+    is == @new_kernel
+  end
+
+  def kernel=(newval)
+    @new_entry[:kernel] = @new_kernel
+  end
+
+  def kernel_options
+    @current_entry[:kernel_options]
+  end
+
+  def kernel_options?(is,should)
+    if @new_entry[:create_output] && @new_entry[:add_defaults_on_creation] && should.include?(':preserve:')
+      should << ':defaults:'
+    end
+
+    default_kernel_options = @default_entry[:kernel_options]
+    if resource[:modules]
+      # We don't want to pick up any default kernel options if this is a multiboot entry.
+      default_kernel_options = {}
+    end
+
+    @new_kernel_options = PuppetX::AugeasprovidersGrub::Util.munged_options(is, should, @default_entry[:kernel], default_kernel_options)
+    old_options = PuppetX::AugeasprovidersGrub::Util.munged_options(is, ':preserve:', @default_entry[:kernel], @default_entry[:kernel_options])
+
+    old_options == @new_kernel_options
+  end
+
+  def kernel_options=(newval)
+    if @new_kernel_options.empty?
+      @new_kernel_options = Array(newval)
+    end
+
+    default_kernel_options = @default_entry[:kernel_options]
+    if resource[:modules]
+      # We don't want to pick up any default kernel options if this is a multiboot entry.
+      default_kernel_options = {}
+    end
+
+    @new_kernel_options = PuppetX::AugeasprovidersGrub::Util.munged_options([], @new_kernel_options, @default_entry[:kernel], default_kernel_options)
+
+    @new_entry[:kernel_options] = @new_kernel_options.join(' ')
+  end
+
+  def modules
+    @current_entry[:modules]
+  end
+
+  def modules?(is,should)
+    @new_modules_options = []
+    old_options = []
+
+    i = 0
+    Array(should).each do |module_set|
+      if @new_entry[:create_output] && @new_entry[:add_defaults_on_creation] && module_set.include?(':preserve:')
+        module_set << ':defaults:'
+      end
+
+      current_val = Array(Array(is)[i])
+      @new_modules_options << PuppetX::AugeasprovidersGrub::Util.munged_options(current_val, module_set, @default_entry[:kernel], @default_entry[:kernel_options], true)
+
+      unless current_val.empty?
+        old_options << PuppetX::AugeasprovidersGrub::Util.munged_options(current_val, ':preserve:', @default_entry[:kernel], @default_entry[:kernel_options], true)
+      end
+
+      i += 1
+    end
+
+    old_options == @new_modules_options
+  end
+
+  def modules=(newval)
+    new_modules_options = @new_modules_options
+
+    if Array(new_modules_options).empty?
+      new_modules_options = []
+      Array(newval).each do |module_set|
+        new_modules_options << PuppetX::AugeasprovidersGrub::Util.munged_options([], module_set, @default_entry[:kernel], @default_entry[:kernel_options])
+      end
+    end
+
+    @new_entry[:modules] = new_modules_options
+  end
+
+  def initrd
+    @current_entry[:initrd]
+  end
+
+  def initrd?(is,should)
+    return true unless should
+
+    @new_initrd = should
+
+    if @new_initrd == ':preserve:'
+      @new_initrd = is
+      if !@new_initrd || @new_initrd.empty?
+        @new_initrd = ':default:'
+      end
+    end
+
+    if @new_initrd == ':default:'
+      @new_initrd = PuppetX::AugeasprovidersGrub::Util.munge_grubby_value(@new_initrd, 'initrd', @grubby_info)
+    end
+
+    unless @new_initrd
+      raise Puppet::Error, 'Could not find a valid initrd value to set'
+    end
+
+    is == @new_initrd
+  end
+
+  def initrd=(newval)
+    @new_entry[:initrd] = @new_initrd
+  end
+
+  def flush
+    unless @new_entry[:create_output]
+      # If we have a modification request, but the target file does not exist,
+      # this means that the entry was picked up from something that is not
+      # Puppet managed and is an error.
+      unless File.exist?(@new_entry[:output_file])
+        raise Puppet::Error, 'Cannot modify a stock system resource; please change your resource :name'
+      end
+    end
+
+    output = []
+
+    output << '#!/bin/sh'
+
+    # We use this to determine if we're puppet managed or not
+    output << '#### PUPPET MANAGED ####'
+    output << 'exec tail -n +3 $0'
+
+    # Build the main menuentry line
+    menuentry_line = ["menuentry '#{@new_entry[:name]}'"]
+
+    if @new_entry[:classes] && !@new_entry[:classes].empty?
+      menuentry_line << @new_entry[:classes].map{|x| x = "--class #{x}"}.join(' ')
+    end
+
+    if @new_entry[:users] && !@new_entry[:users].empty?
+      if @new_entry[:users].map{|x| x.to_s}.include?('unrestricted')
+        menuentry_line << '--unrestricted'
+      else
+        menuentry_line << "--users #{@new_entry[:users].join(',')}"
+      end
+    end
+
+    menuentry_line << '{'
+
+    output << menuentry_line.join(' ')
+    # Main menuentry line complete
+
+    output << '  load_video' if @new_entry[:load_video]
+
+    output += @new_entry[:plugins].map{|x| x = %(  insmod #{x})} if @new_entry[:plugins]
+
+    output << %(  set root='#{@new_entry[:root]}')
+
+    # Build the main kernel line
+    kernel_line = []
+
+    # If we have modules defined, we're in multiboot mode
+    if @new_entry[:modules] && !@new_entry[:modules].empty?
+      if File.exist?('/sys/firmware/efi')
+        output << '  insmod multiboot2'
+      end
+
+      kernel_line << '  multiboot'
+    else
+      if @new_entry[:load_16bit]
+        kernel_line << '  linux16'
+      else
+        kernel_line << '  linux'
+      end
+    end
+
+    kernel_line << @new_entry[:kernel]
+    kernel_line << @new_entry[:kernel_options]
+    output << kernel_line.compact.join(' ')
+
+    if @new_entry[:modules] && !@new_entry[:modules].empty?
+      @new_entry[:modules].each do |mod|
+        output << %(  module #{mod.compact.join(' ')})
+      end
+    else
+      if @new_entry[:load_16bit]
+        output << %(  initrd16 #{@new_entry[:initrd]})
+      else
+        output << %(  initrd #{@new_entry[:initrd]})
+      end
+    end
+
+    output << '}'
+
+    fh = File.open(@new_entry[:output_file], 'w')
+    fh.puts(output.join("\n"))
+    fh.flush
+    fh.close
+
+    FileUtils.chmod(0755, @new_entry[:output_file])
+
+    cfg = nil
+    ["/etc/grub2.cfg", "/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"].each {|c|
+      cfg = c if FileTest.file? c
+    }
+    fail("Cannot find grub.cfg location to use with #{command(:mkconfig)}") unless cfg
+
+    mkconfig "-o", cfg
+
+    if @new_entry[:default_entry]
+      grub_set_default %(#{(Array(@new_entry[:submenus]) + Array(@new_entry[:name])).compact.join('>')})
+    end
+  end
+end

--- a/lib/puppet/provider/grub_user/grub2.rb
+++ b/lib/puppet/provider/grub_user/grub2.rb
@@ -1,0 +1,316 @@
+# GRUB2 support for User Entries
+#
+# Copyright (c) 2016 Trevor Vaughan <tvaughan@onyxpoint.com>
+# Licensed under the Apache License, Version 2.0
+
+Puppet::Type.type(:grub_user).provide(:grub2) do
+  desc "Provides for the manipulation of GRUB2 User Entries"
+
+  has_feature :grub2
+
+  def self.mkconfig_path
+    which("grub2-mkconfig") or which("grub-mkconfig") or '/usr/sbin/grub-mkconfig'
+  end
+
+  commands :mkconfig => mkconfig_path
+
+  confine :exists => '/etc/grub.d'
+
+  defaultfor :osfamily => :RedHat
+
+  mk_resource_methods
+
+  def self.extract_users(content)
+    superusers = nil
+    users = {}
+
+    content.each_line do |line|
+      if line =~ /set\s+superusers=(?:'|")(.+?)(:?'|")/
+        superusers = $1.strip.split(/\s|,|;|\||&/)
+      elsif line =~ /password(?:_pbkdf2)?\s+(.*)/
+        user,password = $1.split(/\s+/)
+        users[user] = password
+      end
+    end
+
+    resources = []
+    users.each_key do |user|
+      new_resource = {}
+      new_resource[:name] = user
+      new_resource[:ensure] = :present
+      new_resource[:password] = users[user]
+
+      if superusers && superusers.include?(user)
+        new_resource[:superuser] = :true
+      else
+        new_resource[:superuser] = :false
+      end
+
+      resources << new_resource
+    end
+
+    return resources
+  end
+
+  def self.instances
+    # Short circuit if we've already gathered this information
+    return @instance_array if @instance_array
+
+    require 'puppetx/augeasproviders_grub/menuentry'
+
+    grub2_config = PuppetX::AugeasprovidersGrub::Util.grub2_cfg
+
+    all_users = extract_users(grub2_config)
+
+    @instance_array = all_users.collect{|x| x = new(x)}
+
+    return @instance_array
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def self.report_unmanaged_users(property_hash)
+    return if @already_reported
+
+    # Report on users that aren't being managed by Puppet
+    unmanaged_users = instances.select do |x|
+      !property_hash[:_all_grub_resource_users].include?(x.name)
+    end
+
+    unmanaged_users.map!{|x| x = x.name}
+
+    unless (property_hash[:ignore_unmanaged_users] == :true) && unmanaged_users.empty?
+      warn(%(The following GRUB2 users are present but not managed by Puppet: "#{unmanaged_users.join('", "')}"))
+    end
+
+    @already_reported = true
+  end
+
+  def self.post_resource_eval
+    # Clean up our class instance variables in case we're running in daemon mode.
+    @instance_array = nil
+    @already_reported = nil
+  end
+
+  def exists?
+    # Make sure that we don't have any issues with the file.
+    if File.exist?(resource[:target])
+      unless File.file?(resource[:target]) && File.readable?(resource[:target])
+        raise(Puppet::Error, "'#{resource[:target]}' exists but is not a readable file")
+      end
+
+      # Save this for later so that we don't write the file if it doesn't need it.
+      @property_hash[:_target_file_content] = File.read(resource[:target]).strip
+      @property_hash[:_existing_users] = self.class.extract_users(@property_hash[:_target_file_content]).collect{|x| x[:_puppet_managed] = true; x}
+
+      # We don't want to duplicate our current entry
+      current_index = @property_hash[:_existing_users].index{|x| x[:name] == resource[:name]}
+      if current_index
+        @property_hash[:_puppet_managed] = true
+        @property_hash[:_existing_users].delete_at(current_index)
+      end
+    else
+      @property_hash[:_existing_users] = []
+    end
+
+    # This is used later on to ensure that we retain all entries that are
+    # actually in the catalog.
+    #
+    # It only applies if we actually are performing a catalog run.
+    @property_hash[:_all_grub_resource_users] = []
+    if resource.catalog
+      @property_hash[:_all_grub_resource_users] = resource.catalog.resources.select{|x|
+        x.type == :grub_user
+      }.map{|x|
+        x = x[:name]
+      }
+    end
+
+    if resource[:report_unmanaged] == :true
+      self.class.report_unmanaged_users(@property_hash)
+    end
+
+    # Get the password into a sane format before proceeding
+
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    # Input Validation
+    fail(Puppet::Error, '`password` is a required property') unless (@property_hash[:password] || resource[:password])
+    # End Validation
+
+    @property_hash = resource.to_hash.merge(@property_hash)
+    @property_hash[:_puppet_managed] = true
+  end
+
+  def destroy
+    @property_hash[:_puppet_managed] = false
+  end
+
+  def password?(is,should)
+    if is =~ /^grub\.pbkdf2\.\S+\.(\d+)/
+      is_rounds = $1
+
+      if should =~ /^grub\.pbkdf2\.\S+\.(\d+)/
+        should_rounds = $1
+
+        return (is == should) && (is_rounds == should_rounds)
+      else
+        return validate_pbkdf2(should,is)
+      end
+    end
+
+    if should =~ /^grub\.pbkdf2\.\S+\.(\d+)/
+      should_rounds = $1
+
+      if is =~ /^grub\.pbkdf2\.\S+\.(\d+)/
+        is_rounds = $1
+
+        return (is == should) && (is_rounds == should_rounds)
+      else
+        return validate_pbkdf2(is,should)
+      end
+    else
+      should = mkpasswd_pbkdf2(should, nil, resource[:rounds])
+    end
+
+    return is == should
+  end
+
+  def purge
+    users_to_purge = []
+    if resource[:purge] == :true
+      (@property_hash[:_existing_users] + [@property_hash]).each do |user|
+        unless (user[:_puppet_managed] && @property_hash[:_all_grub_resource_users].include?(user[:name]))
+          # Found something to purge!
+          users_to_purge << user[:name]
+        end
+      end
+    end
+
+    if users_to_purge.empty?
+      return resource[:purge]
+    else
+      return %(Purged GRUB2 users: "#{users_to_purge.join('", "')}")
+    end
+  end
+
+  def flush
+    output = []
+
+    output << <<-EOM
+#!/bin/sh
+########
+# This file managed by Puppet
+# Manual changes will be erased!
+########
+exec tail -n +3 $0
+    EOM
+
+    # Build the password file
+    superusers = @property_hash[:_existing_users].select{|x| x[:superuser] == :true}.map{|x| x = x[:name]}
+    if @property_hash[:_puppet_managed] && (@property_hash[:superuser] == :true)
+      superusers << @property_hash[:name]
+    end
+
+    # First, prepare the superusers line.
+    unless superusers.empty?
+      output << %(set superusers="#{superusers.uniq.sort.join(',')}")
+    end
+
+    # Now, prepare our user list
+    users = []
+    # Need to keep our output order consistent!
+    (@property_hash[:_existing_users] + [@property_hash]).sort_by{|x| x[:name]}.each do |user|
+      if resource[:purge] == :true
+        if user[:_puppet_managed] && @property_hash[:_all_grub_resource_users].include?(user[:name])
+          users << format_user_entry(user)
+        else
+          debug("Purging GRUB2 User #{user[:name]}")
+        end
+      else
+        users <<  format_user_entry(user)
+      end
+    end
+
+    output += users
+
+    output = output.join("\n")
+
+    # This really shouldn't happen but could if people start adding users in other files.
+    if output == @property_hash[:_target_file_content]
+      err("Please ensure that your *active* GRUB2 configuration is correct. #{self.class} thinks that you need an update, but your file content did not change")
+    else output == @property_hash[:_target_file_content]
+      fh = File.open(resource[:target], 'w')
+      fh.puts(output)
+      fh.flush
+      fh.close
+
+      FileUtils.chmod(0755, resource[:target])
+    end
+
+    cfg = nil
+    ["/etc/grub2.cfg", "/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"].each {|c|
+      cfg = c if FileTest.file? c
+    }
+    fail("Cannot find grub.cfg location to use with #{command(:mkconfig)}") unless cfg
+
+    mkconfig "-o", cfg
+  end
+
+  private
+
+  def format_user_entry(user_hash)
+    password = user_hash[:password]
+
+    unless password =~ /^grub\.pbkdf2/
+      password = mkpasswd_pbkdf2(password, nil, resource[:rounds])
+    end
+
+    user_entry = %(password_pbkdf2 #{user_hash[:name]} #{password})
+
+    return user_entry
+  end
+
+  def pack_salt(salt)
+    return salt.scan(/../).map{|x| x.hex }.pack('c*')
+  end
+
+  def unpack_salt(salt)
+    return salt.unpack('H*').first.upcase
+  end
+
+  def mkpasswd_pbkdf2(password, salt, rounds=10000)
+    salt ||= (0...63).map{|x| x = (65 + rand(26)).chr }.join
+
+    require 'openssl'
+
+    digest = OpenSSL::Digest::SHA512.new
+
+    hashed_password = OpenSSL::PKCS5.pbkdf2_hmac(password, salt, rounds, digest.digest_length, digest).unpack('H*').first.upcase
+
+    return "grub.pbkdf2.sha512.#{rounds}.#{unpack_salt(salt)}.#{hashed_password}"
+  end
+
+  def validate_pbkdf2(password, pbkdf2_hash)
+    if pbkdf2_hash =~ /(grub\.pbkdf2.*)/
+      pbkdf2_hash = $1
+    else
+      raise "Error: No valid GRUB2 PBKDF2 password hash found"
+    end
+
+    id, type, algorithm, rounds, hashed_salt, hashed_password = pbkdf2_hash.split('.')
+    rounds = rounds.to_i
+
+    salt = pack_salt(hashed_salt)
+
+    return "grub.pbkdf2.sha512.#{rounds}.#{hashed_salt}.#{hashed_password}" == mkpasswd_pbkdf2(password, salt, rounds)
+  end
+end

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -149,7 +149,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
       cfg = c if FileTest.file? c
     }
     fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg
-    
+
     super
     mkconfig "-o", cfg
   end

--- a/lib/puppet/type/grub_config.rb
+++ b/lib/puppet/type/grub_config.rb
@@ -1,0 +1,87 @@
+# Manages GRUB global parameters (non-boot entry)
+#
+# Author Trevor Vaughan <tvaughan@onyxpoint.com>
+# Copyright (c) 2015 Onyx Point, Inc.
+# Licensed under the Apache License, Version 2.0
+# Based on work by Dominic Cleal
+
+Puppet::Type.newtype(:grub_config) do
+  @doc = "Manages global GRUB configuration parameters"
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name) do
+    desc <<-EOM
+      The parameter that you wish to set.
+
+      ## GRUB < 2 ##
+
+      In the case of GRUB < 2, this will be something like 'default',
+      'timeout', etc...
+
+      See `info grub` for additional information.
+
+      ## GRUB >= 2 ##
+
+      With GRUB >= 2, this will be 'GRUB_DEFAULT', 'GRUB_SAVEDEFAULT', etc..
+
+      See `info grub2` for additional information.
+    EOM
+
+    isnamevar
+  end
+
+  newparam(:target) do
+    desc <<-EOM
+      The bootloader configuration file, if in a non-default location for the
+      provider.
+    EOM
+  end
+
+  newproperty(:value) do
+    desc <<-EOM
+      Value of the GRUB parameter.
+    EOM
+  end
+
+  autorequire(:file) do
+    reqs = []
+
+    if self[:target]
+      reqs << self[:target]
+    end
+
+    reqs
+  end
+
+  autorequire(:kernel_parameter) do
+    reqs = []
+
+    kernel_parameters = catalog.resources.find_all { |r|
+      r.is_a?(Puppet::Type.type(:kernel_parameter)) && (r[:target] == self[:target])
+    }
+
+    # Handles conflicts with Grub >= 2 since this and kernel_parameter would edit
+    # the same file.
+    #
+    # Ignored for Grub < 2
+    kernel_parameters.each do |kparam|
+      if kparam[:bootmode].to_s == 'all'
+        if self[:name].to_s == 'GRUB_CMDLINE_LINUX'
+          raise Puppet::ParseError, "Conflicting resource #{kparam.to_s} defined"
+        end
+      elsif ['default','normal'].include?(kparam[:bootmode].to_s)
+        if self[:name].to_s == 'GRUB_CMDLINE_LINUX_DEFAULT'
+          raise Puppet::ParseError, "Conflicting resource #{kparam.to_s} defined"
+        end
+      end
+
+      reqs << kparam
+    end
+
+    reqs
+  end
+end

--- a/lib/puppet/type/grub_menuentry.rb
+++ b/lib/puppet/type/grub_menuentry.rb
@@ -1,0 +1,299 @@
+# Manages GRUB kernel menu items
+#
+# Focuses on linux-compatible menu items.
+#
+# Author Trevor Vaughan <tvaughan@onyxpoint.com>
+# Copyright (c) 2015 Onyx Point, Inc.
+# Licensed under the Apache License, Version 2.0
+# Based on work by Dominic Cleal
+
+Puppet::Type.newtype(:grub_menuentry) do
+  @doc = <<-EOM
+    Manages menu entries in the GRUB and GRUB2 systems.
+
+    NOTE: This may not cover all possible options and some options may apply to
+          either GRUB or GRUB2!
+  EOM
+
+  feature :grub, "Can handle Legacy GRUB settings"
+  feature :grub2, "Can handle GRUB2 settings"
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name) do
+    desc <<-EOM
+      The name of the menu entry.
+    EOM
+
+    isnamevar
+  end
+
+  newparam(:target, :required_features => %w(grub)) do
+    desc <<-EOM
+      The bootloader configuration file, if in a non-default location for the
+      provider.
+    EOM
+  end
+
+  newparam(:load_16bit, :boolean => true, :required_featurees => %w(grub2)) do
+    desc <<-EOM
+      If set, ensure that linux16 and initrd16 are used for the kernel entries.
+    EOM
+
+    newvalues(:true, :false)
+
+    defaultto :true
+  end
+
+  newparam(:add_defaults_on_creation, :boolean => true) do
+    desc <<-EOM
+      If set, when using the ':preserve:' option in `kernel_options` or
+      `modules` will add the system defaults if the entry is being first
+      created. This is the same technique that grub2-mkconfig uses when
+      procesing entries.
+    EOM
+
+    newvalues(:true, :false)
+
+    defaultto :true
+  end
+
+  # Shared Properties
+  newproperty(:root) do
+    desc <<-EOM
+      The filesystem root.
+    EOM
+
+    newvalues(/\(.*\)/)
+  end
+
+  newproperty(:default_entry, :boolean => true) do
+    desc <<-EOM
+      If set, make this menu entry the default entry.
+
+      If more than one of these is defined across all :menuentry resources,
+      this is an error.
+
+      In GRUB2, there is no real guarantee that this will stick since entries
+      further down the line may have custom scripts which alter the default.
+
+      NOTE: You should not use this in conjunction with using the :grub_config
+            type to set the system default.
+    EOM
+    newvalues(:true, :false)
+
+    defaultto :false
+  end
+
+  newproperty(:kernel) do
+    desc <<-EOM
+      The path to the kernel that you wish to boot.
+
+      Set this to ':default:' to copy the default kernel if one exists.
+
+      Set this to ':preserve:' to preserve the current entry. If a current
+      entry does not exist, the default will be copied. If there is no default,
+      this is an error.
+    EOM
+
+    newvalues(/^(\/.*|:(default|preserve):)/)
+
+    def insync?(is)
+      provider.kernel?(is,should)
+    end
+  end
+
+  newproperty(:kernel_options, :array_matching => :all) do
+    desc <<-EOM
+      An array of kernel options to apply to the :kernel property.
+
+       The following format is supported for the new options:
+         ':defaults:'  => Copy defaults from the default GRUB entry
+         ':preserve:'  => Preserve all existing options (if present)
+
+         Note: ':defaults:' and ':preserve:' are mutually exclusive.
+
+         All of the options below supersede any items affected by the above
+
+         'entry(=.*)?'   => Ensure that `entry` exists *as entered*; replaces all
+                            other options with the same name
+         '!:entry(=.*)?' => Add this option to the end of the arguments
+                            preserving any other options of the same name
+         '-:entry'       => Ensure that all instances of `entry` do not exist
+         '-:entry=foo'   => Ensure that only instances of `entry` with value `foo` do not exist
+
+      Note: Option removals and additions have higher precedence than preservation
+    EOM
+
+    defaultto(':preserve:')
+
+    validate do |value|
+      if value.include?(':defaults:') && value.include?(':preserve:')
+        raise Puppet::ParseError, "Only one of :defaults: or :preserve: may be specified"
+      end
+    end
+
+    def insync?(is)
+      provider.kernel_options?(is,should)
+    end
+  end
+
+  newproperty(:modules, :array_matching => :all) do
+    desc <<-EOM
+      An Array of module entry Arrays that apply to the given entry.
+      Since each Multiboot format boot image is unique, you must know what you
+      wish to pass to the module lines.
+
+      The one exception to this is that many of the linux multiboot settings
+      require the kernel and initrd to be passed to them. If you set the
+      ':defaults:' value anywhere in the options array, the default kernel
+      options will be copied to that location in the output.
+
+      The following format is supported for the new options:
+        ':defaults:'  => Copy default options from the default *kernel* GRUB entry
+        ':preserve:'  => Preserve all existing options (if present)
+
+        Note: ':defaults:' and ':preserve:' are mutually exclusive.
+
+        All of the options below supersede any items affected by the above
+
+          'entry(=.*)?'   => Ensure that `entry` exists *as entered*; replaces all
+                           other options with the same name
+          '!:entry(=.*)?' => Add this option to the end of the arguments
+                           preserving any other options of the same name
+          '-:entry'       => Ensure that all instances of `entry` do not exist
+          '-:entry=foo'   => Ensure that only instances of `entry` with value `foo` do not exist
+
+        Note: Option removals and additions have higher precedence than preservation
+
+      Example:
+        modules => [
+          ['/vmlinuz.1.2.3.4','ro'],
+          ['/initrd.1.2.3.4']
+        ]
+    EOM
+
+    validate do |value|
+      unless value.is_a?(Array) && (value.first.is_a?(Array) || value.first.is_a?(String))
+        raise Puppet::ParseError, ':modules requires an Array of Arrays'
+      end
+
+      value.each do |val_line|
+        if val_line.include?(':defaults:') && val_line.include?(':preserve:')
+          raise Puppet::ParseError, "Only one of :defaults: or :preserve: may be specified"
+        end
+      end
+    end
+
+    def insync?(is)
+      provider.modules?(is,should)
+    end
+
+    def is_to_s(value)
+      return '"' + Array(Array(value).map{|x| x.join(' ')}).join("\n") + '"'
+    end
+
+    def should_to_s(value)
+      return '"' + Array(Array(value).map{|x| x.join(' ')}).join("\n") + '"'
+    end
+  end
+
+  newproperty(:initrd) do
+    desc <<-EOM
+      The path to the initrd image.
+
+      Set this to ':default:' to copy the default kernel initrd if one exists.
+
+      Set this to ':preserve:' to preserve the current entry. If a current
+      entry does not exist, the default will be copied. If there is no default,
+      this is an error.
+    EOM
+
+    newvalues(/^(\/.*|:(default|preserve):)/)
+
+    def insync?(is)
+      provider.initrd?(is,should)
+    end
+  end
+
+  # GRUB Legacy only properties
+=begin
+# This currently does not function properly as the 'lock' entry is misaligned within an entry.
+  newproperty(:lock, :boolean => true, :required_features => %w(grub)) do
+    desc <<-EOM
+      In Legacy GRUB, having this set will add a 'lock' entry to the menuentry.
+    EOM
+    newvalues(:true, :false)
+
+    defaultto :false
+  end
+=end
+
+  newproperty(:makeactive, :boolean => true, :required_features => %w(grub)) do
+    desc <<-EOM
+      In Legacy GRUB, having this set will add a 'makeactive' entry to the menuentry.
+    EOM
+    newvalues(:true, :false)
+
+    defaultto :false
+  end
+
+  # GRUB2 only properties
+  newproperty(:classes, :array_matching => :all, :required_features => %w(grub2)) do
+    desc <<-EOM
+      Add this Array of classes to the menuentry.
+    EOM
+  end
+
+  newproperty(:users, :array_matching => :all, :required_features => %w(grub2)) do
+    desc <<-EOM
+      In GRUB2, having this set will add a requirement for the listed users to
+      authenticate to the system in order to utilize the menu entry.
+    EOM
+
+    defaultto [:unrestricted]
+
+    munge do |value|
+      value = Array(value).map{|x| x.to_s.strip.split(/\s|,|;|\||&/)}.flatten.join(',')
+    end
+  end
+
+  newproperty(:load_video, :boolean => true, :required_features => %w(grub2)) do
+    desc <<-EOM
+      If true, add the `load_video` command to the menuentry.
+    EOM
+    newvalues(:true, :false)
+
+    defaultto :true
+  end
+
+  newproperty(:plugins, :array_matching => :all, :required_features => %w(grub2)) do
+    desc <<-EOM
+      An Array of plugins that should be included in this menuentry.
+    EOM
+
+    defaultto ['gzio','part_msdos','xfs','ext2']
+  end
+
+  # Autorequires
+  autorequire(:file) do
+    reqs = []
+
+    if self[:target]
+      reqs << self[:target]
+    end
+
+    reqs
+  end
+
+  autorequire(:kernel_parameter) do
+    kernel_parameters = catalog.resources.find_all { |r|
+      r.is_a?(Puppet::Type.type(:kernel_parameter)) && (r[:target] == self[:target])
+    }
+
+    kernel_parameters
+  end
+end

--- a/lib/puppet/type/grub_user.rb
+++ b/lib/puppet/type/grub_user.rb
@@ -1,0 +1,110 @@
+# Manages GRUB2 Users - Does not apply to GRUB Legacy
+#
+# Author Trevor Vaughan <tvaughan@onyxpoint.com>
+# Copyright (c) 2015 Onyx Point, Inc.
+
+Puppet::Type.newtype(:grub_user) do
+  @doc = <<-EOM
+    Manages GRUB2 Users - Does not apply to GRUB Legacy
+
+    Note: This type compares against the *active* GRUB configuration. The
+    contents of the management file will not be updated unless the active
+    configuration is out of sync with the expected configuration.
+  EOM
+
+  feature :grub2, 'Management of GRUB2 resources'
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name) do
+    desc <<-EOM
+      The username of the GRUB2 user to be managed.
+    EOM
+
+    isnamevar
+
+    validate do |value|
+      # These are items that can separate users in the superusers string and,
+      # therefore, should not be valid as a username.
+      if value =~ /\s|,|;|&|\|/
+        raise(Puppet::ParseError, "Usernames may not contain spaces, commas, semicolons, ampersands, or pipes")
+      end
+    end
+  end
+
+  newparam(:superuser, :boolean => true) do
+    desc <<-EOM
+      If set, add this user to the 'superusers' list, if no superusers are set,
+      but grub_user resources have been declared, a compile error will be
+      raised.
+    EOM
+
+    newvalues(:true, :false)
+
+    defaultto(:false)
+  end
+
+  newparam(:target) do
+    desc <<-EOM
+      The file to which to write the user information.
+
+      Must be an absolute path.
+    EOM
+
+    newvalues(/^\/.+/)
+    defaultto('/etc/grub.d/01_puppet_managed_users')
+  end
+
+  newparam(:report_unmanaged, :boolean => true) do
+    desc <<-EOM
+      Report any unmanaged users as a warning during the Puppet run.
+    EOM
+
+    newvalues(:true, :false)
+    defaultto(:false)
+  end
+
+  newparam(:rounds) do
+    desc <<-EOM
+      The rounds to use when hashing the password.
+    EOM
+
+    newvalues(/^\d+$/)
+    defaultto(10000)
+
+    munge do |value|
+      value.to_i
+    end
+  end
+
+  newproperty(:purge, :boolean => true) do
+    desc <<-EOM
+      Purge all unmanaged users.
+
+      This does not affect any users that are not defined by Puppet! There is
+      no way to reliably eliminate the items from all other scripts without
+      potentially severely damaging the GRUB2 build scripts.
+    EOM
+
+    newvalues(:true, :false)
+    defaultto(:false)
+  end
+
+  newproperty(:password) do
+    desc <<-EOM
+      The user's password. If the password is not already in a GRUB2 compatible
+      form, it will be automatically converted.
+    EOM
+
+    validate do |value|
+      raise(Puppet::ParseError, "Passwords must be Strings") unless value.is_a?(String)
+    end
+
+    def insync?(is)
+      provider.password?(is,should)
+    end
+  end
+end

--- a/lib/puppet/type/kernel_parameter.rb
+++ b/lib/puppet/type/kernel_parameter.rb
@@ -6,7 +6,10 @@
 Puppet::Type.newtype(:kernel_parameter) do
   @doc = "Manages kernel parameters stored in bootloaders."
 
-  ensurable
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
 
   newparam(:name) do
     desc "The parameter name, e.g. 'quiet' or 'vga'."

--- a/lib/puppetx/augeasproviders_grub/menuentry.rb
+++ b/lib/puppetx/augeasproviders_grub/menuentry.rb
@@ -1,0 +1,168 @@
+module PuppetX
+  module AugeasprovidersGrub
+    module Util
+      # Return a merge of the system options and the new options.
+      #
+      # The following format is supported for the new options
+      # ':defaults:'  => Copy defaults from the default GRUB entry
+      # ':preserve:'  => Preserve all existing options (if present)
+      #
+      # ':defaults:' and ':preserve:' are mutually exclusive!
+      #
+      # All of the options below supersede any items affected by the above
+      #
+      # 'entry(=.*)?' => Ensure that `entry` exists *as entered*; replaces all
+      #                  other options with the same name
+      # '!entry(=.*)? => Add this option to the end of the arguments,
+      #                  preserving any other options of the same name
+      # '-:entry'     => Ensure that all instances of `entry` do not exist
+      # '-:entry=foo' => Ensure that only instances of `entry` with value `foo` do not exist
+      #
+      # @param system_opts [Array] the current system options for this entry
+      # @param new_opts [Array] the new options for this entry
+      # @param default_opts [Array] the default entry options (if applicable)
+      # @return [Array] a merged/manipulated array of options
+      def self.munge_options(system_opts, new_opts, default_opts=[])
+        sys_opts = Array(system_opts).flatten.map(&:strip)
+        opts     = Array(new_opts).flatten.map(&:strip)
+        def_opts = Array(default_opts).flatten.map(&:strip)
+
+        result_opts = []
+
+        if opts.delete(':defaults:')
+          result_opts += def_opts
+        end
+
+        if opts.delete(':preserve:')
+          # Need to remove any result opts that are being preserved
+          sys_opts_keys = sys_opts.map{|x| x = x.split('=').first.strip}
+
+          result_opts.delete_if do |x|
+            key = x.split('=').first.strip
+
+            sys_opts_keys.include?(key)
+          end
+
+          result_opts += sys_opts
+        end
+
+        # Get rid of everything with a '-:'
+        discards = Array(opts.select{|x| x =~ /^-:/}.map{|x| x = x[2..-1]})
+        opts.delete_if{|x| x =~ /^-:/}
+
+        result_opts.delete_if{|x|
+          discards.index{|d|
+            ( d == x ) || ( d == x.split('=').first )
+          }
+        }
+
+        # Prepare to append everything with a '!:'
+        appends = Array(opts.select{|x| x =~ /^!:/}.map{|x| x = x[2..-1]})
+        opts.delete_if{|x| x =~ /^!:/}
+
+        # We only want to append items that aren't in the list already
+        appends.delete_if{|x| result_opts.include?(x)}
+
+        # Replace these items in place if possible
+        tmp_results = []
+        new_results = []
+
+        opts.each do |opt|
+          key = opt.split('=').first
+
+          old_entry = result_opts.index{|x| x.split('=').first == key}
+
+          if old_entry
+            # Replace the first instance of a given item with the matching option.
+            tmp_results[old_entry] = opt
+            result_opts.map!{|x| x = (x.split('=').first == key) ? nil : x}
+          else
+            # Keep track of everything that we aren't replacing
+            new_results << opt
+          end
+        end
+
+        # Copy in all of the remaining options in place
+        result_opts.each_index do |i|
+          if result_opts[i]
+            tmp_results[i] = result_opts[i]
+          end
+        end
+
+        result_opts = tmp_results.compact + new_results + appends
+        return result_opts
+      end
+
+      # Take care of copying ':default:' values and ensure that the leading
+      # 'boot' entries are stripped off of passed entries.
+      #
+      # @value (String) The value to munge
+      # @flavor (String) The section in the 'grubby' output to use (kernel, initrd, etc...)
+      # @grubby_info (Hash) The broken down output of 'grubby' into a Hash
+      # @returns (String) The cleaned value
+      def self.munge_grubby_value(value, flavor, grubby_info)
+        if value == ':default:'
+          if grubby_info.empty? || !grubby_info[flavor]
+            raise Puppet::Error, "No default GRUB information found for `#{flavor}`"
+          end
+
+          value = grubby_info[flavor]
+
+          # In some cases, /boot gets shoved on by GRUB and we can't compare againt
+          # that.
+          value = value.split('/')
+          if value[1] == 'boot'
+            value.delete_at(1)
+          end
+
+          value = value.join('/')
+        end
+
+        return value
+      end
+
+      # Return the location of the GRUB2 configuration on the system.
+      # Raise an error if not found.
+      #
+      # @return (String) The full path to the GRUB2 configuration file.
+      def self.grub2_cfg
+        paths = [
+          '/boot/grub2/grub.cfg',
+          '/boot/grub/grub.cfg',
+          '/etc/grub2-efi.cfg',
+          '/etc/grub2.cfg'
+        ]
+
+        paths.each do |path|
+          return File.read(path) if (File.readable?(path) && !File.directory?(path))
+        end
+
+        raise Puppet::Error, 'Could not find a GRUB2 configuration on the system'
+      end
+
+      # Return a list of options that have the kernel path prepended and are
+      # formatted with all processing arguments handled.
+      #
+      # @param old_opts (Array[String]) An array of all old options
+      # @param new_opts (Array[String]) An array of all new options
+      # @param default_kernel (String) The default kernel
+      # @param default_kernel_opts (Array[String]) The default kernel options
+      # @param prepend_kernel_path (Boolean) If true, add the kernel itself to the default kernel options
+      # @return (Array[String]) An Array of processed options
+      def self.munged_options(old_opts, new_opts, default_kernel, default_kernel_opts, prepend_kernel_path=false)
+        # You need to prepend the kernel path for the defaults if you're trying to
+        # format for `module` lines.
+
+        default_kernel_opts = Array(default_kernel_opts)
+
+        if default_kernel
+          if prepend_kernel_path
+            default_kernel_opts = Array(default_kernel) + default_kernel_opts
+          end
+        end
+
+        return munge_options(old_opts, new_opts, default_kernel_opts)
+      end
+    end
+  end
+end

--- a/spec/acceptance/grub2_users_spec.rb
+++ b/spec/acceptance/grub2_users_spec.rb
@@ -1,0 +1,146 @@
+require 'spec_helper_acceptance'
+
+test_name 'Augeasproviders Grub'
+
+describe 'GRUB2 User Tests' do
+  hosts.each do |host|
+    if fact_on(host,'osfamily') == 'RedHat'
+      if fact_on(host,'operatingsystemmajrelease').to_s >= '7'
+        let(:target_files) {
+          [
+            '/etc/grub.d/01_puppet_managed_users',
+            '/etc/grub2.cfg'
+          ]
+        }
+
+        let(:password_info) {{
+          :plain_password      => 'really bad password',
+          :hashed_password     => 'grub.pbkdf2.sha512.10000.3ED7C861BA4107282E3A55FC80B549995D105324F2CB494BBF34DE86517DFCB8DCFCA3E0C3550C64F9A259B516BFDD928C0FAC4E66CFDA351A957D702EE32C3D.C589ED8757DB23957A5F946470A58CF216A7507634647E532BC68085AAA52622AB4E6E151CF60CD8409166F6581FC166CE4D4845D61353A4C439C2170CC25747',
+          :hashed_password_20k => 'grub.pbkdf2.sha512.20000.4CD886B13634E03CF533C3F4C27E59E8F67D9C62915C04E03B019651FFB1DE8BE9EBB09B0D5759CF94A502566D748C28E9AF2150E81BFF1202E66D3C417A28A1.62E1AE32B4746DCBF222EB22FA670D35E7FAAD438677D67A0A1275E79430CF4E0F31EBF2186E645E922109B973CFF9A71BD53DCA77D9E749BDEC302022FD00BE'
+        }}
+
+        context 'set a user on the system with a plain text password' do
+          let(:manifest) { %(
+            grub_user { 'test_user1':
+              password => '#{password_info[:plain_password]}'
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should set an encrypted password' do
+            target_files.each do |target_file|
+              result = on(host, %(grep 'password_pbkdf2 test_user1' #{target_file})).stdout
+
+              password_identifier, user, password_hash = result.split(/\s+/)
+              expect(user).to eql('test_user1')
+              expect(password_hash).to match(/grub\.pbkdf2\.sha512\.10000\..*/)
+            end
+          end
+        end
+
+        context 'set a user on the system with a hashed password' do
+          let(:manifest) { %(
+            grub_user { 'test_user1':
+              password => '#{password_info[:hashed_password]}'
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, :catch_changes => true)
+          end
+
+          it 'should set an encrypted password' do
+            target_files.each do |target_file|
+              result = on(host, %(grep 'password_pbkdf2 test_user1' #{target_file})).stdout
+
+              password_identifier, user, password_hash = result.split(/\s+/)
+              expect(user).to eql('test_user1')
+              expect(password_hash).to eql(password_info[:hashed_password])
+            end
+          end
+        end
+
+        context 'set a user on the system with a hashed password with 20000 rounds' do
+          let(:manifest) { %(
+            grub_user { 'test_user1':
+              password => '#{password_info[:hashed_password_20k]}',
+              rounds   => '20000'
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should set an encrypted password' do
+            target_files.each do |target_file|
+              result = on(host, %(grep 'password_pbkdf2 test_user1' #{target_file})).stdout
+
+              password_identifier, user, password_hash = result.split(/\s+/)
+              expect(user).to eql('test_user1')
+              expect(password_hash).to eql(password_info[:hashed_password_20k])
+            end
+          end
+        end
+
+        context 'should purge any users when purge is set' do
+          let(:manifest) { %(
+            grub_user { 'test_user1':
+              password => '#{password_info[:hashed_password]}',
+              purge    => true
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should purge unmanaged users' do
+            on(host, %(puppet resource grub_user bad_user password='some password'))
+
+            result = apply_manifest_on(host, manifest, :catch_failures => true).stdout
+            expect(result).to match(/Purged.*bad_user/)
+
+            target_files.each do |target_file|
+              result = on(host, %(grep 'password_pbkdf2 test_user1' #{target_file})).stdout
+
+              password_identifier, user, password_hash = result.split(/\s+/)
+              expect(user).to eql('test_user1')
+              expect(password_hash).to eql(password_info[:hashed_password])
+
+              result = on(
+                host,
+                %(grep 'password_pbkdf2 bad_user' #{target_file}),
+                :acceptable_exit_codes => [1]
+              ).stdout
+              expect(result).to be_empty
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/grub_config_spec.rb
+++ b/spec/acceptance/grub_config_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper_acceptance'
+
+test_name 'Augeasproviders Grub'
+
+describe 'Global Config Tests' do
+  hosts.each do |host|
+    if fact_on(host,'osfamily') == 'RedHat'
+      if fact_on(host,'operatingsystemmajrelease').to_s <= '6'
+        context 'set timeout in grub' do
+          let(:manifest) { %(
+            grub_config { 'timeout':
+              value    => '1'
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should have a timeout of 1' do
+            on(host, %(grep "timeout=1" /etc/grub.conf))
+          end
+        end
+
+        context 'set invalid variable in grub' do
+          let(:manifest) { %(
+            grub_config { 'foobar': }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should fail to apply' do
+            result = apply_manifest_on(host, manifest, :expect_failures => true)
+            expect(result.output).to match(/Grub_config\[foobar\].*Failed to save Augeas tree/)
+          end
+        end
+
+        context 'set fallback in grub' do
+          let(:manifest) { %(
+            grub_config { 'fallback':
+              value    => '0'
+            }
+          )}
+
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should have a fallback of 0' do
+            on(host, %(grep "fallback 0" /etc/grub.conf))
+          end
+        end
+      else
+        context 'set timeout in grub2' do
+          let(:manifest) { %(
+            grub_config { 'GRUB_TIMEOUT':
+              value    => '1'
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should have a timeout of 1' do
+            on(host, %(grep "GRUB_TIMEOUT=1" /etc/default/grub))
+            on(host, %(grep "timeout=1" /boot/grub2/grub.cfg))
+          end
+        end
+
+        context 'set arbitrary value in grub2' do
+          let(:manifest) { %(
+            grub_config { 'GRUB_FOOBAR':
+              value    => 'BAZ'
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should have a GRUB_FOOBAR of BAZ' do
+            on(host, %(grep "GRUB_FOOBAR=BAZ" /etc/default/grub))
+          end
+        end
+
+        context 'remove value in grub2' do
+          let(:manifest) { %(
+            grub_config { 'GRUB_FOOBAR':
+              ensure => 'absent'
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should not have a GRUB_FOOBAR' do
+            on(host, %(grep "GRUB_FOOBAR" /etc/default/grub), :acceptable_exit_codes => [1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/grub_menuentry_spec.rb
+++ b/spec/acceptance/grub_menuentry_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper_acceptance'
+
+test_name 'Augeasproviders Grub'
+
+describe 'GRUB Menuentry Tests' do
+  hosts.each do |host|
+    if fact_on(host,'osfamily') == 'RedHat'
+      if fact_on(host,'operatingsystemmajrelease').to_s <= '6'
+        context 'set new default kernel in GRUB Legacy' do
+          let(:manifest) { %(
+            grub_menuentry { 'Standard':
+              default_entry  => true,
+              root           => '(hd0,0)',
+              kernel         => ':preserve:',
+              initrd         => ':preserve:',
+              kernel_options => [':preserve:', 'iam=GROOT']
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should have set the default to the new entry' do
+            result = on(host, %(grubby --info=DEFAULT | grep 'args=')).stdout
+            expect(result).to match(/iam=GROOT/)
+          end
+
+          it 'should activate on reboot' do
+            host.reboot
+
+            result = on(host, %(cat /proc/cmdline)).stdout
+            expect(result.split(/\s+/)).to include('iam=GROOT')
+          end
+        end
+      else
+        context 'set new default kernel in GRUB2' do
+          let(:manifest) { %(
+            grub_menuentry { 'Standard':
+              default_entry  => true,
+              root           => '(hd0,msdos1)',
+              kernel         => ':preserve:',
+              initrd         => ':preserve:',
+              kernel_options => [':preserve:', 'trogdor=BURNINATE']
+            }
+          )}
+
+          # Using puppet_apply as a helper
+          it 'should work with no errors' do
+            apply_manifest_on(host, manifest, :catch_failures => true)
+          end
+
+          it 'should be idempotent' do
+            apply_manifest_on(host, manifest, {:catch_changes => true})
+          end
+
+          it 'should have set the default to the new entry' do
+            result = on(host, %(grubby --info=DEFAULT)).stdout
+            result_hash = {}
+            result.each_line do |line|
+              line =~ /^\s*(.*?)=(.*)\s*$/
+              result_hash[$1.strip] = $2.strip
+            end
+
+            expect(result_hash['title']).to eq('Standard')
+            expect(result_hash['args']).to match(/trogdor=BURNINATE/)
+          end
+
+          it 'should activate on reboot' do
+            host.reboot
+
+            result = on(host, %(cat /proc/cmdline)).stdout
+            expect(result.split(/\s+/)).to include('trogdor=BURNINATE')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/kernel_parameter_spec.rb
+++ b/spec/acceptance/kernel_parameter_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper_acceptance'
 
 test_name 'Augeasproviders Grub'
 
-describe 'Grub Tests' do
+describe 'Kernel Parameter Tests' do
   tests = {
     :basic => {
       :manifest => %(
         kernel_parameter { 'audit':
           value    => '1'
         }),
-      :test => %(grep "audit=1" /proc/cmdline)
+      :test => %(grep -q "audit=1" /proc/cmdline)
     },
     :normal_bootmode => {
       :manifest => %(
@@ -17,7 +17,7 @@ describe 'Grub Tests' do
           value    => '1',
           bootmode => 'normal'
         }),
-      :test => %(grep "audit=1" /proc/cmdline)
+      :test => %(grep -q "audit=1" /proc/cmdline)
     }
   }
 
@@ -31,12 +31,17 @@ describe 'Grub Tests' do
         it 'should work with no errors' do
           apply_manifest_on(host, manifest, :catch_failures => true)
         end
-    
+
         it 'should be idempotent' do
           apply_manifest_on(host, manifest, {:catch_changes => true})
         end
-    
+
         it 'is expected to have auditing enabled at boot time' do
+          # Scrub out any custom boot entries that were added by other GRUB2
+          # tests
+          on(host, 'rm -rf /etc/grub.d/05_puppet_managed*')
+          on(host, 'which grub2-mkconfig > /dev/null 2>&1 && grub2-mkconfig -o /etc/grub2.cfg', :accept_all_exit_codes => true)
+
           host.reboot
           on(host, test)
         end


### PR DESCRIPTION
This patch adds support for grub_menuentry which provides the ability to
manage individual Menu entries for both GRUB Legacy and GRUB2.

Testing has been focused on Linux-based operating systems and it is
possible that features may be missing for chainloaded operating systems.

Support for managing GRUB2 users has also been added. This compares
against the *running* configuration, not what is saved in the
compilation files in grub.d.

The following custom types were created:
  * grub_config => Manages global GRUB settings
  * grub_menuentry => Manages GRUB menuentries
  * grub_user => Manages GRUB2 users

Fixes hercules-team/augeasproviders_grub#10