### PR TITLE
Update grub2.rb to add On UEFI Systems, grub.cfg

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -148,7 +148,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
 
   def flush
     cfg = nil
-    ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg", "/boot/efi/EFI/fedora/grub.cfg"].each {|c|
+    ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg", "/boot/efi/EFI/fedora/grub.cfg", "/etc/grub2-efi.cfg"].each {|c|
       cfg = c if FileTest.file? c
     }
     fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg


### PR DESCRIPTION
On UEFI Systems, grub.cfg will be located at: /boot/efi/EFI/**_distribution_**/grub.cfg
For example, On RedHat UEFI-based systems, the configuration file is /boot/efi/EFI/**_redhat_**/grub.cfg.
/etc/grub2-efi.cfg is a symlink to that EFI File and that's the one I modified to avoid the following error on UEFI RHEL7 Systems and update grub configuration
_Could not evaluate: Cannot find grub.cfg location to use with grub-mkconfig_