### PR TITLE
Raise exception on missing augeasproviders_core

### DIFF
--- a/lib/puppet/provider/grub_config/grub.rb
+++ b/lib/puppet/provider/grub_config/grub.rb
@@ -4,6 +4,7 @@
 # Licensed under the Apache License, Version 2.0
 # Based on work by Dominic Cleal
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:grub_config).provide(:grub, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update kernel parameters in GRUB's menu.lst"
 

--- a/lib/puppet/provider/grub_config/grub2.rb
+++ b/lib/puppet/provider/grub_config/grub2.rb
@@ -4,6 +4,7 @@
 # Licensed under the Apache License, Version 2.0
 # Based on work by Dominic Cleal
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:grub_config).provide(:grub2, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update kernel parameters in GRUB2's /etc/default/grub"
 

--- a/lib/puppet/provider/grub_menuentry/grub.rb
+++ b/lib/puppet/provider/grub_menuentry/grub.rb
@@ -4,6 +4,7 @@
 # Licensed under the Apache License, Version 2.0
 # Based on work by Dominic Cleal
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:grub_menuentry).provide(:grub, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update GRUB menu entries"
 

--- a/lib/puppet/provider/kernel_parameter/grub.rb
+++ b/lib/puppet/provider/kernel_parameter/grub.rb
@@ -3,6 +3,7 @@
 # Copyright (c) 2013 Dominic Cleal
 # Licensed under the Apache License, Version 2.0
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:kernel_parameter).provide(:grub, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update kernel parameters in GRUB's menu.lst"
 

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -3,6 +3,7 @@
 # Copyright (c) 2012 Dominic Cleal
 # Licensed under the Apache License, Version 2.0
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update kernel parameters in GRUB2's /etc/default/grub"
 


### PR DESCRIPTION
People who manage their code with r10k have to resolve dependencies by
hand (or using a generator), as such we now helpfully raise an exception
when miaugeasproviders_core is missing.