### PR TITLE
Add Global EFI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 dist: precise
 sudo: required
 rvm:
-  - 2.0.0
+  - 2.1.9
   # Ruby with Puppet 5
   - 2.4.0
 notifications:
@@ -20,11 +20,11 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - PUPPET=5.0 RUBY_AUGEAS=0.5
+    - env: PUPPET=5.0 RUBY_AUGEAS=0.5
   exclude:
 # base exclude
-    # No support for Ruby 2.0.0 in Puppet 5
-    - rvm: 2.0.0
+    # No support for Ruby 2.1.9 in Puppet 5
+    - rvm: 2.1.9
       env: PUPPET=5.0 RUBY_AUGEAS=0.5
 
 install:
@@ -43,5 +43,5 @@ deploy:
     # all_branches is required to use tags
     all_branches: true
     # Only publish if our main Ruby target builds
-    rvm: 2.0.0
+    rvm: 2.1.9
     condition: "$FORGE_PUBLISH = true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,66 +1,31 @@
 language: ruby
+dist: precise
 sudo: required
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
+  # Ruby with Puppet 5
+  - 2.4.0
 notifications:
   email:
    - raphael.pinson@camptocamp.com
 env:
 # base env
-  # Most tests with oldest supported ruby-augeas
-  - PUPPET=3.0.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-  - PUPPET=3.2.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-  # Test the latest ruby-augeas (~>)
-  - PUPPET=3.2.0 RUBY_AUGEAS=0.5
-    # Use this build to publish on the forge
-  - PUPPET=3.4 RUBY_AUGEAS=0.5 FORGE_PUBLISH=true
-  # Test other versions of Augeas
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=0.10.0
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-  - PUPPET=2.7.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
-  # Issue #83: test old Augeas with new lenses
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
-  - PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
-  - PUPPET=3.4 RUBY_AUGEAS=0.5 AUGEAS=1.0.0 LENSES=HEAD
-  - PUPPET=3.4 RUBY_AUGEAS=0.5 AUGEAS=1.1.0 LENSES=HEAD
-  # Test latest Puppet version
+  # Test Puppet 4
   - PUPPET=4.0 RUBY_AUGEAS=0.5
-
+  # Test Oldest Puppet, Inc. supported Puppet
+  - PUPPET=4.7.1 RUBY_AUGEAS=0.5 FORGE_PUBLISH=true
+  # Test latest Puppet version
+  - PUPPET=5.0 RUBY_AUGEAS=0.5
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - PUPPET=5.0 RUBY_AUGEAS=0.5
   exclude:
 # base exclude
-    # No support for Ruby 2.0 before Puppet 3.2.0 and ruby-augeas 0.5
+    # No support for Ruby 2.0.0 in Puppet 5
     - rvm: 2.0.0
-      env: PUPPET=3.0.0 RUBY_AUGEAS=0.3.0
-    - rvm: 2.0.0
-      env: PUPPET=3.2.0 RUBY_AUGEAS=0.3.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=0.10.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-    - rvm: 2.0.0
-      env: PUPPET=3.0.0 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.2.0
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.0.0 LENSES=HEAD
-    - rvm: 2.0.0
-      env: PUPPET=3.4 RUBY_AUGEAS=0.3.0 AUGEAS=1.1.0 LENSES=HEAD
-    # No support for Ruby 1.8 in Puppet 4
-    - rvm: 1.8.7
-      env: PUPPET=4.0 RUBY_AUGEAS=0.5
-
+      env: PUPPET=5.0 RUBY_AUGEAS=0.5
 
 install:
   - "travis_retry ./.travis.sh"
@@ -78,5 +43,5 @@ deploy:
     # all_branches is required to use tags
     all_branches: true
     # Only publish if our main Ruby target builds
-    rvm: 1.9.3
+    rvm: 2.0.0
     condition: "$FORGE_PUBLISH = true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.0.0
+
+- Added code to fix the EFI stack on Linux hosts
+- Restricted the RHEL and CentOS support to only what can be tested
+- Pinned supported puppet versions between 4.7.2 and 5.0.0
+  - This is the oldes Puppet, Inc. supported version and there are currently
+    issues in 5.X
+
 ## 2.4.0
 
 - Add support for global GRUB configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Added code to fix the EFI stack on Linux hosts
 - Restricted the RHEL and CentOS support to only what can be tested
 - Pinned supported puppet versions between 4.7.2 and 5.0.0
-  - This is the oldes Puppet, Inc. supported version and there are currently
+  - This is the oldest Puppet, Inc. supported version and there are currently
     issues in 5.X
 
 ## 2.4.0

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 if ENV.key?('PUPPET')
   puppetversion = "~> #{ENV['PUPPET']}"
 else
-  puppetversion = ['>= 2.7']
+  puppetversion = ['>= 2.7', '< 5']
 end
 gem 'puppet', puppetversion
 

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -154,9 +154,24 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
   end
 
   def flush
+    os_name = Facter.value(:os)['name']
+
+    # Support for old versions of Facter
+    unless os_name
+      os_name = Facter.value(:operatingsystem)
+    end
     cfg = nil
-    ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg", "/boot/efi/EFI/fedora/grub.cfg", "/etc/grub2-efi.cfg"].each {|c|
-      cfg = c if FileTest.file? c
+    [
+      "/boot/grub/grub.cfg",
+      "/boot/grub2/grub.cfg",
+      # Handle the standard EFI naming convention
+      "/boot/efi/EFI/#{os_name.downcase}/grub.cfg",
+      "/etc/grub2-efi.cfg"
+    ].each {|c|
+      if FileTest.file?(c) || ( FileTest.symlink?(c) &&
+          FileTest.directory?(File.dirname(File.absolute_path(File.readlink(c)))) )
+        cfg = c
+      end
     }
     fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg
 

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -154,23 +154,30 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
   end
 
   def flush
-    os_name = Facter.value(:os)['name']
-
-    # Support for old versions of Facter
-    unless os_name
-      os_name = Facter.value(:operatingsystem)
+    os_info = Facter.value(:os)
+    if os_info
+      os_name = Facter.value(:os)['name']
+    else
+      # Support for old versions of Facter
+      unless os_name
+        os_name = Facter.value(:operatingsystem)
+      end
     end
+
     cfg = nil
     [
-      "/boot/grub/grub.cfg",
-      "/boot/grub2/grub.cfg",
+      "/etc/grub2-efi.cfg",
       # Handle the standard EFI naming convention
       "/boot/efi/EFI/#{os_name.downcase}/grub.cfg",
-      "/etc/grub2-efi.cfg"
+      "/boot/grub2/grub.cfg",
+      "/boot/grub/grub.cfg"
     ].each {|c|
       if FileTest.file?(c) || ( FileTest.symlink?(c) &&
           FileTest.directory?(File.dirname(File.absolute_path(File.readlink(c)))) )
+
         cfg = c
+        break
+
       end
     }
     fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "herculesteam-augeasproviders_grub",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "author": "Dominic Cleal, Raphael Pinson, Trevor Vaughan",
   "summary": "Augeas-based grub types and providers for Puppet",
   "license": "Apache-2.0",
@@ -38,8 +38,13 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "4",
-        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
         "6",
         "7"
       ]
@@ -48,7 +53,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 2.7.0 < 5.0.0"
+      "version_requirement": ">= 4.7.1 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
* Updated EFI support
* Added tests for Puppet 5 and Ruby 2.4.0
* Added compatiblity with CentOS
* Restricted RHEL and CentOS versions to those that can be tested
* Eliminated old Ruby versions from the tests since they fundamentally
  break

Closes #27