### PR TITLE
Update grub2.rb for EFI systems

### DIFF
--- a/lib/puppet/provider/grub_user/grub2.rb
+++ b/lib/puppet/provider/grub_user/grub2.rb
@@ -256,8 +256,25 @@ exec tail -n +3 $0
       FileUtils.chmod(0755, resource[:target])
     end
 
+    os_info = Facter.value(:os)
+    if os_info
+      os_name = Facter.value(:os)['name']
+    else
+      # Support for old versions of Facter
+      unless os_name
+        os_name = Facter.value(:operatingsystem)
+      end
+    end
+
     cfg = nil
-    ["/etc/grub2.cfg", "/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"].each {|c|
+    [
+      "/etc/grub2-efi.cfg",
+      # Handle the standard EFI naming convention
+      "/boot/efi/EFI/#{os_name.downcase}/grub.cfg",
+      "/etc/grub2.cfg",
+      "/boot/grub/grub.cfg",
+      "/boot/grub2/grub.cfg"
+    ].each {|c|
       cfg = c if FileTest.file? c
     }
     fail("Cannot find grub.cfg location to use with #{command(:mkconfig)}") unless cfg


### PR DESCRIPTION
Fixed EFI-based grub configuration in grub_user resource based on work done with kernel_parameter grub2.rb fix.