### PR TITLE
Add back path for grub.cfg on Debian OS.

### DIFF
--- a/lib/puppetx/augeasproviders_grub/menuentry.rb
+++ b/lib/puppetx/augeasproviders_grub/menuentry.rb
@@ -128,6 +128,7 @@ module PuppetX
       def self.grub2_cfg_path
         paths = [
           '/etc/grub2.cfg',
+          '/boot/grub/grub.cfg',
           '/boot/grub2/grub.cfg'
         ]
 


### PR DESCRIPTION
This was removed in e773a9a02d2a8d0cdecee658ba9b58d346f0b3bb
without any mentioning in the commit message.