### PR TITLE
Fixed the EFI code for grub_config and grub_menuentry

### DIFF
--- a/lib/puppet/provider/grub_config/grub2.rb
+++ b/lib/puppet/provider/grub_config/grub2.rb
@@ -78,8 +78,24 @@ Puppet::Type.type(:grub_config).provide(:grub2, :parent => Puppet::Type.type(:au
   end
 
   def flush
+    os_info = Facter.value(:os)
+    if os_info
+      os_name = Facter.value(:os)['name']
+    else
+      # Support for old versions of Facter
+      unless os_name
+        os_name = Facter.value(:operatingsystem)
+      end
+    end
+
     cfg = nil
-    ["/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"].each {|c|
+    [
+      "/etc/grub2-efi.cfg",
+      # Handle the standard EFI naming convention
+      "/boot/efi/EFI/#{os_name.downcase}/grub.cfg",
+      "/boot/grub2/grub.cfg",
+      "/boot/grub/grub.cfg"
+    ].each {|c|
       cfg = c if FileTest.file? c
     }
     fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg

--- a/lib/puppet/provider/grub_menuentry/grub2.rb
+++ b/lib/puppet/provider/grub_menuentry/grub2.rb
@@ -538,8 +538,24 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
 
     FileUtils.chmod(0755, @new_entry[:output_file])
 
+    os_info = Facter.value(:os)
+    if os_info
+      os_name = Facter.value(:os)['name']
+    else
+      # Support for old versions of Facter
+      unless os_name
+        os_name = Facter.value(:operatingsystem)
+      end
+    end
+
     cfg = nil
-    ["/etc/grub2.cfg", "/boot/grub/grub.cfg", "/boot/grub2/grub.cfg"].each {|c|
+    [
+      "/etc/grub2-efi.cfg",
+      # Handle the standard EFI naming convention
+      "/boot/efi/EFI/#{os_name.downcase}/grub.cfg",
+      "/boot/grub2/grub.cfg",
+      "/boot/grub/grub.cfg"
+    ].each {|c|
       cfg = c if FileTest.file? c
     }
     fail("Cannot find grub.cfg location to use with #{command(:mkconfig)}") unless cfg


### PR DESCRIPTION
The grub.cfg path was not being found for grub_config and grub_menuentry providers with EFI and grub2.  This pull request fixes that.