### PR TITLE
Add BLS support to grub_menuentry

### DIFF
--- a/lib/puppet/provider/grub_menuentry/grub.rb
+++ b/lib/puppet/provider/grub_menuentry/grub.rb
@@ -92,7 +92,7 @@ Puppet::Type.type(:grub_menuentry).provide(:grub, :parent => Puppet::Type.type(:
         kernel = aug.get("#{pp}/kernel")
         initrd = aug.get("#{pp}/initrd")
         fs_root = aug.get("#{pp}/root")
-        default_entry = ((aug.get("$target/default") || '0').to_i + 1).to_s.to_sym
+        default_entry = ((aug.get("$target/default") || '0').to_i + 1)
 
         modules = self.class.get_modules(aug, pp)
 
@@ -100,10 +100,8 @@ Puppet::Type.type(:grub_menuentry).provide(:grub, :parent => Puppet::Type.type(:
           :name          => entry_name,
           :ensure        => :present,
           :root          => fs_root,
-          :default_entry => (pp.split('[').last[0].chr == default_entry).to_s.to_sym,
-          # Broken in the lens
-          #:lock          => aug.exists("#{pp}/lock").to_s.to_sym,
-          :makeactive    => aug.exists("#{pp}/makeactive").to_s.to_sym
+          :default_entry => (pp.split('[').last[0].chr == default_entry),
+          :makeactive    => aug.exists("#{pp}/makeactive")
         }
 
         if kernel
@@ -249,7 +247,7 @@ Puppet::Type.type(:grub_menuentry).provide(:grub, :parent => Puppet::Type.type(:
   end
 
   def default_entry
-    return (menu_entry_index == @default_entry[:index]).to_s.to_sym
+    menu_entry_index == @default_entry[:index]
   end
 
   def default_entry=(newval)
@@ -367,12 +365,6 @@ Puppet::Type.type(:grub_menuentry).provide(:grub, :parent => Puppet::Type.type(:
     process_option_line(new_kernel_options,'kernel')
   end
 
-  def lock
-    augopen do |aug|
-      return aug.exists("#{menu_entry_path}/lock").to_s.to_sym
-    end
-  end
-
   def modules
     augopen do |aug|
       self.class.get_modules(aug, menu_entry_path)
@@ -427,7 +419,7 @@ Puppet::Type.type(:grub_menuentry).provide(:grub, :parent => Puppet::Type.type(:
 
   def makeactive
     augopen do |aug|
-      return aug.exists("#{menu_entry_path}/makeactive").to_s.to_sym
+      aug.exists("#{menu_entry_path}/makeactive")
     end
   end
 

--- a/lib/puppet/provider/grub_menuentry/grub2.rb
+++ b/lib/puppet/provider/grub_menuentry/grub2.rb
@@ -8,18 +8,21 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
 
   has_feature :grub2
 
+  # Populate the default methods
+  mk_resource_methods
+
   #### Class Methods
   def self.mkconfig_path
     which("grub2-mkconfig") or which("grub-mkconfig") or '/usr/sbin/grub-mkconfig'
   end
 
   # Return an Array of system resources culled from a full GRUB2
-  # configuration
+  # mkconfig-generated configuration
   #
   # @param config (String) The output of grub2-mkconfig or the grub2.cfg file
   # @param current_default (String) The name of the current default GRUB entry
   # @return (Array) An Array of resource Hashes
-  def self.grub2_menuentries(config, current_default)
+  def self.grub2_mkconfig_menuentries(config, current_default)
     resources = []
 
     # Pull out the menuentries into our resources
@@ -36,14 +39,10 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
       # The main menuentry line
       if line =~ /^\s*menuentry '(.+?)'/
         resource = {
-          :name => $1
+          :name => $1,
+          :bls  => false
         }
-
-        if resource[:name] == current_default
-          resource[:default_entry] = true
-        else
-          resource[:default_entry] = false
-        end
+        resource[:default_entry] = (resource[:name] == current_default)
 
         if in_menuentry
           raise Puppet::Error, "Malformed config file received"
@@ -128,15 +127,135 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
     return resources
   end
 
+  # Return an Array of system resources based on processing the BLS stack
+  #
+  # This is required for systems that use the BLS Grub2 module
+  #
+  # @param current_default (String) The name of the current default GRUB entry
+  # @return (Array) An Array of resource Hashes
+  def self.grub2_bls_menuentries(current_default)
+
+    resources = []
+
+    begin
+      grubenv = File.read('/boot/grub2/grubenv').lines.
+        # Remove comments
+        reject{|l| l.start_with?('#')}.
+        # Create a hash of all of the key/value entries in the file
+        map{|l| l.strip.split(/^(.+?)=(.+)$/).reject(&:empty?) }.to_h
+
+      require 'puppet/util/package'
+      # This is how grubby does it
+      # See https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault
+      Dir.glob('/boot/loader/entries/*.conf').sort{|x,y| Puppet::Util::Package.versioncmp(y, x)}.each do |file|
+        config = File.read(file)
+
+        puppet_managed = config.include?('### PUPPET MANAGED ###')
+
+        # Before we begin processing, replace all environment variables with their
+        # corresponding setting from `grubenv` above
+        #
+        # This doesn't catch everything because we aren't processing the entire
+        # grub2.cfg file but it's about the best we can do
+        grubenv.each do |k,v|
+          config.gsub!(/\$#{k}(\s+|$)/){ "#{v}#{$1}" }
+        end
+
+        config = config.lines.map(&:strip)
+
+        # Process out args that could occur multiple times
+        #
+        # The specs are completely unclear on how this actually works, so we're
+        # taking a wild stab and assuming that plural things can be space
+        # separated and non-plural things can only have one item.
+        #
+        users,config = config.partition{|x| x.match?(/^grub_users\s+/)}
+        users.map!{|x| x.split(/\s+/)}
+        users.flatten!
+        users.delete('grub_users')
+        users.sort
+
+        args,config = config.partition{|x| x.match?(/^grub_arg\s+/)}
+        args.map!{|x| x.split(/\s+/)}
+        args.flatten!
+        args.delete('grub_arg')
+        args.sort
+
+        classes,config = config.partition{|x| x.match?(/^grub_class\s+/)}
+        classes.map!{|x| x.split(/\s+/)}
+        classes.flatten!
+        classes.delete('grub_class')
+        classes.sort
+
+        # Convert the rest of the config to a Hash for ease of use
+        config = config.reject{|l| l.start_with?('#')}.map{|l| l.split(/^(.+?)\s+(.+)$/).reject(&:empty?) }.to_h
+
+        resource = {
+          :name           => config['title'],
+          :bls            => true,
+          :bls_target     => file,
+          :puppet_managed => puppet_managed,
+          :default_entry  => false
+        }
+
+        resource[:default_entry] = (resource[:name] == current_default)
+
+        if args.include?('--unrestricted')
+          resource[:users] = [:unrestricted]
+          args.delete('--unrestricted')
+        elsif !users.empty?
+          resource[:users] = users
+        end
+
+        resource[:args]           = args unless args.empty?
+        resource[:classes]        = classes unless classes.empty?
+        resource[:kernel]         = config['linux']
+        resource[:kernel_options] = config['options']
+        resource[:initrd]         = config['initrd']
+
+        resources << resource
+      end
+    rescue => e
+      debug("Exception while processing BLS entries => #{e}")
+    end
+
+    return resources
+  end
+
+  # Return an Array of system resources culled from the system GRUB2
+  # configuration
+  #
+  # @param config (String) The output of grub2-mkconfig or the grub2.cfg file
+  # @param current_default (String) The name of the current default GRUB entry
+  # @return (Array) An Array of resource Hashes
+  def self.grub2_menuentries(config, current_default)
+    resources = grub2_mkconfig_menuentries(config, current_default)
+    resources += grub2_bls_menuentries(current_default) if config.match?(/^blscfg$/)
+
+    return resources
+  end
+
   def self.instances
     require 'puppetx/augeasproviders_grub/menuentry'
 
-    if (grubby '--info=DEFAULT') =~ /^\s*title=(.+)\s*$/
-      current_default = ($2.to_i - 1)
+    @grubby_default_index ||= (grubby '--default-index').strip
+
+    current_default = nil
+    if (grubby "--info=#{@grubby_default_index}") =~ /^\s*title=(.+)\s*$/
+      current_default = $1.delete('"')
     end
 
     grub2_menuentries(PuppetX::AugeasprovidersGrub::Util.grub2_cfg, current_default).map{|x| x = new(x)}
   end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
   #### End Class Methods
 
   commands :mkconfig => mkconfig_path
@@ -154,12 +273,13 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
 
     @grubby_info = {}
     begin
-      grubby_raw = grubby '--info=DEFAULT'
+      @grubby_default_index = (grubby '--default-index').strip
+      grubby_raw = grubby "--info=#{@grubby_default_index}"
 
       grubby_raw.each_line do |opt|
         key,val = opt.to_s.split('=')
 
-        @grubby_info[key.strip] = val.strip
+        @grubby_info[key.strip] = val.strip.delete('"')
       end
     rescue Puppet::ExecutionFailure
       @grubby_info = {}
@@ -170,198 +290,130 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
     end
 
     # Things that we really only want to do once...
-    @menu_entries = self.class.grub2_menuentries(PuppetX::AugeasprovidersGrub::Util.grub2_cfg, current_default)
-
-    current_index = @menu_entries.index { |x| x[:name] == self.name }
-
-    if current_index
-      @current_entry = @menu_entries[current_index]
-    else
-      @current_entry = {}
-    end
+    menu_entries = self.class.grub2_menuentries(PuppetX::AugeasprovidersGrub::Util.grub2_cfg, current_default)
 
     # These only matter if we're trying to manipulate a resource
 
     # Extract the default entry for reference later
-    @default_entry = @menu_entries.select{|x| x[:default_entry] }.first
-    raise(Puppet::Error, "Could not find a default GRUB2 entry. Check your system grub configuration using `grubby --info=DEFAULT`") unless @default_entry
+    @default_entry = menu_entries.select{|x| x[:default_entry] }.first
+    raise(Puppet::Error, "Could not find a default GRUB2 entry. Check your system grub configuration using `grubby --info=`grubby --default-index``") unless @default_entry
 
-    require 'openssl'
-    random_file_ext = OpenSSL::Digest::SHA256.new.digest(self.name).unpack('H*').first.upcase[0..11]
-    @new_entry = @current_entry.dup
-
-    @new_entry[:name] = self.name
-    @new_entry[:output_file] = "/etc/grub.d/05_puppet_managed_#{random_file_ext}"
+    @bls_system = (menu_entries.find{|x| x[:bls]} ? true : false)
   end
 
+  # Prepping material here for use in other functions since this is always
+  # called first.
   def exists?
-    @new_entry[:load_16bit] = (resource[:load_16bit] == :true)
-    @new_entry[:add_defaults_on_creation] = (resource[:add_defaults_on_creation] == :true)
+    require 'openssl'
 
-    !@current_entry.empty?
+    @property_hash[:id] = OpenSSL::Digest::SHA256.new.digest(self.name).unpack('H*').first
+
+    @property_hash[:target] = resource[:target] if resource[:target]
+    @property_hash[:add_defaults_on_creation] = resource[:add_defaults_on_creation]
+
+    @property_hash[:bls] = @bls_system && (@property_hash[:bls] || (@property_hash[:bls].nil? && (resource[:bls].nil? || resource[:bls])))
+
+    # BLS and non-BLS systems must be treated differently
+    if @property_hash[:bls] || resource[:bls]
+      @property_hash[:args] ||= []
+    else @property_hash[:bls]
+      @property_hash[:load_16bit] ||= resource[:load_16bit].nil? ? true : resource[:load_16bit]
+      @property_hash[:load_video] ||= resource[:load_video].nil? ? true : resource[:load_video]
+      @property_hash[:plugins] ||= resource[:plugins].nil? ? true : resource[:plugins]
+    end
+
+    retval = @property_hash[:name] == resource[:name]
+    unless resource[:bls].nil?
+      retval = retval && (resource[:bls] == @property_hash[:bls])
+      @property_hash[:bls] = resource[:bls]
+    end
+
+    retval
   end
 
   def create
     # Input Validation
+    fail Puppet::Error, '`root` is a required property' unless resource[:root] unless bls
     fail Puppet::Error, '`kernel` is a required property' unless resource[:kernel]
-    fail Puppet::Error, '`root` is a required property' unless resource[:root]
-
-    unless resource[:modules]
-      fail Puppet::Error, '`initrd` is a required parameter' unless resource[:initrd]
-    end
+    fail Puppet::Error, '`initrd` is a required parameter' unless resource[:modules] || resource[:initrd]
     # End Validation
 
-    @new_entry[:create_output] = true
+    @property_hash[:create_output]  = true
+    @property_hash[:users]          = resource[:users] || []
+    @property_hash[:initrd]         = get_initrd('', resource[:initrd])
+    @property_hash[:kernel]         = get_kernel('', resource[:kernel])
+    @property_hash[:kernel_options] = get_kernel_options([], resource[:kernel_options])[:new_kernel_options]
+    @property_hash[:modules]        = get_module_options([], resource[:modules])[:new_module_options]
+    @property_hash[:default_entry]  = resource[:default_entry]
 
-    self.root=(resource[:root])
-
-    # Need to prime this to reduce duplication later
-    self.kernel?([],resource[:kernel])
-    self.kernel=(resource[:kernel])
-
-    if resource[:users]
-      self.users=(resource[:users])
-    end
-
-    if resource[:classes]
-      self.classes=(resource[:classes])
-    end
-
-    if resource[:load_video]
-      self.load_video=(resource[:load_video])
-    end
-
-    if resource[:plugins]
-      self.plugins=(resource[:plugins])
-    end
-
-    # Need to prime this to reduce duplication later
-    self.initrd?([],resource[:initrd])
-    self.initrd=(resource[:initrd])
-
-    if resource[:kernel_options]
-      # Need to prime this to reduce duplication later
-      self.kernel_options?([],resource[:kernel_options])
-      self.kernel_options=(resource[:kernel_options])
-    end
-
-    if resource[:modules]
-      # Need to prime this to reduce duplication later
-      self.modules?([],resource[:modules])
-      self.modules=(resource[:modules])
-    end
-
-    if resource[:default_entry]
-      self.default_entry=(resource[:default_entry])
+    if bls
+      @property_hash[:classes] = resource[:classes] || ['kernel']
+    else
+      @property_hash[:classes]    = resource[:classes] || []
+      @property_hash[:root]       = resource[:root]
+      @property_hash[:load_16bit] = resource[:load_16bit]
+      @property_hash[:load_video] = resource[:load_video]
+      @property_hash[:plugins]    = resource[:plugins]
     end
   end
 
   def destroy
-    if File.exist?(@new_entry[:output_file])
-      FileUtils.rm_f(@new_entry[:output_file])
-    end
-  end
-
-  def classes
-    @current_entry[:classes]
+    @property_hash[:destroy] = true
   end
 
   def classes=(newval)
-    @new_entry[:classes] = newval
-  end
-
-  def users
-    if @current_entry[:users]
-      Array(Array(@current_entry[:users]).join(','))
-    end
+    @property_hash[:classes] = newval
   end
 
   def users=(newval)
-    @new_entry[:users] = newval
+    @property_hash[:users] = newval
+  end
+
+  def load_16bit=(newval)
+    @property_hash[:load_16bit] = newval
   end
 
   def load_video
-    @current_entry[:load_video].to_s.to_sym
+    bls ? resource[:load_video] : @property_hash[:load_video]
   end
 
   def load_video=(newval)
-    @new_entry[:load_video] = (newval == :true)
+    @property_hash[:load_video] = newval
   end
 
   def plugins
-    @current_entry[:plugins]
+    bls ? resource[:plugins] : @property_hash[:plugins]
   end
 
   def plugins=(newval)
-    @new_entry[:plugins] = newval
-  end
-
-  def default_entry
-    @current_entry[:default_entry].to_s.to_sym
-  end
-
-  def default_entry=(newval)
-    @new_entry[:default_entry] = (newval.to_s == 'true')
+    @property_hash[:plugins] = newval
   end
 
   def root
-    @current_entry[:root]
+    bls ? resource[:root] : @property_hash[:root]
   end
 
   def root=(newval)
-    @new_entry[:root] = newval
+    @property_hash[:root] = newval
   end
 
-  def kernel
-    @current_entry[:kernel]
-  end
-
-  def kernel?(is,should)
+  def kernel?(is, should)
     return true unless should
 
-    @new_kernel = should
-
-    if @new_kernel == ':preserve:'
-      @new_kernel = is
-      if !@new_kernel || @new_kernel.empty?
-        @new_kernel = ':default:'
-      end
-    end
-
-    if @new_kernel == ':default:'
-      @new_kernel = PuppetX::AugeasprovidersGrub::Util.munge_grubby_value(@new_kernel, 'kernel', @grubby_info)
-    end
-
-    unless @new_kernel
-      raise Puppet::Error, 'Could not find a valid kernel value to set'
-    end
+    @new_kernel = get_kernel(is, should)
 
     is == @new_kernel
   end
 
   def kernel=(newval)
-    @new_entry[:kernel] = @new_kernel
-  end
-
-  def kernel_options
-    @current_entry[:kernel_options]
+    @property_hash[:kernel] = @new_kernel
   end
 
   def kernel_options?(is,should)
-    if @new_entry[:create_output] && @new_entry[:add_defaults_on_creation] && should.include?(':preserve:')
-      should << ':defaults:'
-    end
+    kernel_options = get_kernel_options(is,should)
 
-    default_kernel_options = @default_entry[:kernel_options]
-    if resource[:modules]
-      # We don't want to pick up any default kernel options if this is a multiboot entry.
-      default_kernel_options = {}
-    end
-
-    @new_kernel_options = PuppetX::AugeasprovidersGrub::Util.munged_options(is, should, @default_entry[:kernel], default_kernel_options)
-    old_options = PuppetX::AugeasprovidersGrub::Util.munged_options(is, ':preserve:', @default_entry[:kernel], @default_entry[:kernel_options])
-
-    old_options == @new_kernel_options
+    @new_kernel_options = kernel_options[:new_kernel_options]
+    kernel_options[:old_kernel_options] == @new_kernel_options
   end
 
   def kernel_options=(newval)
@@ -377,110 +429,269 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
 
     @new_kernel_options = PuppetX::AugeasprovidersGrub::Util.munged_options([], @new_kernel_options, @default_entry[:kernel], default_kernel_options)
 
-    @new_entry[:kernel_options] = @new_kernel_options.join(' ')
-  end
-
-  def modules
-    @current_entry[:modules]
+    @property_hash[:kernel_options] = @new_kernel_options.join(' ')
   end
 
   def modules?(is,should)
-    @new_modules_options = []
-    old_options = []
+    module_options = get_module_options(is,should)
+
+    @new_module_options = module_options[:new_module_options]
+
+    module_options[:old_module_options] == @new_module_options
+  end
+
+  def get_module_options(is, should, default_entry=@default_entry)
+    new_module_options = []
+    old_module_options = []
 
     i = 0
     Array(should).each do |module_set|
-      if @new_entry[:create_output] && @new_entry[:add_defaults_on_creation] && module_set.include?(':preserve:')
+      if @property_hash[:create_output] && @property_hash[:add_defaults_on_creation] && module_set.include?(':preserve:')
         module_set << ':defaults:'
       end
 
       current_val = Array(Array(is)[i])
-      @new_modules_options << PuppetX::AugeasprovidersGrub::Util.munged_options(current_val, module_set, @default_entry[:kernel], @default_entry[:kernel_options], true)
+      new_module_options << PuppetX::AugeasprovidersGrub::Util.munged_options(current_val, module_set, default_entry[:kernel], default_entry[:kernel_options], true)
 
       unless current_val.empty?
-        old_options << PuppetX::AugeasprovidersGrub::Util.munged_options(current_val, ':preserve:', @default_entry[:kernel], @default_entry[:kernel_options], true)
+        old_module_options << PuppetX::AugeasprovidersGrub::Util.munged_options(current_val, ':preserve:', default_entry[:kernel], default_entry[:kernel_options], true)
       end
 
       i += 1
     end
 
-    old_options == @new_modules_options
+    return {:new_module_options => new_module_options, :old_module_options => old_module_options}
   end
 
   def modules=(newval)
-    new_modules_options = @new_modules_options
+    new_module_options = @new_module_options
 
-    if Array(new_modules_options).empty?
-      new_modules_options = []
+    if Array(new_module_options).empty?
+      new_module_options = []
       Array(newval).each do |module_set|
-        new_modules_options << PuppetX::AugeasprovidersGrub::Util.munged_options([], module_set, @default_entry[:kernel], @default_entry[:kernel_options])
+        new_module_options << PuppetX::AugeasprovidersGrub::Util.munged_options([], module_set, @default_entry[:kernel], @default_entry[:kernel_options])
       end
     end
 
-    @new_entry[:modules] = new_modules_options
-  end
-
-  def initrd
-    @current_entry[:initrd]
+    @property_hash[:modules] = new_module_options
   end
 
   def initrd?(is,should)
     return true unless should
 
-    @new_initrd = should
-
-    if @new_initrd == ':preserve:'
-      @new_initrd = is
-      if !@new_initrd || @new_initrd.empty?
-        @new_initrd = ':default:'
-      end
-    end
-
-    if @new_initrd == ':default:'
-      @new_initrd = PuppetX::AugeasprovidersGrub::Util.munge_grubby_value(@new_initrd, 'initrd', @grubby_info)
-    end
-
-    unless @new_initrd
-      raise Puppet::Error, 'Could not find a valid initrd value to set'
-    end
+    @new_initrd = get_initrd(is, should)
 
     is == @new_initrd
   end
 
   def initrd=(newval)
-    @new_entry[:initrd] = @new_initrd
+    @property_hash[:initrd] = @new_initrd
   end
 
   def flush
-    unless @new_entry[:create_output]
-      # If we have a modification request, but the target file does not exist,
-      # this means that the entry was picked up from something that is not
-      # Puppet managed and is an error.
-      unless File.exist?(@new_entry[:output_file])
-        raise Puppet::Error, 'Cannot modify a stock system resource; please change your resource :name'
+    @property_hash[:name] = self.name
+
+    if @property_hash[:kernel] =~ /(\d.+)/
+      bls_version = $1
+    else
+      bls_version = @property_hash[:kernel].dup
+      bls_version.delete('/')
+    end
+
+    bls_target = @property_hash[:bls_target] ||
+      File.join('',
+          'boot',
+          'loader',
+          'entries',
+          "#{@property_hash[:id][0...32]}-#{bls_version}.conf"
+         )
+
+    legacy_target = @property_hash[:target] ||
+      "/etc/grub.d/05_puppet_managed_#{@property_hash[:id].upcase[0...10]}"
+
+    output = []
+
+    if bls
+      if @property_hash[:destroy]
+        FileUtils.rm_f(property_hash[:bls_target])
+      else
+
+        if @property_hash[:bls_target] && !@property_hash[:target]
+          @property_hash[:target] = @property_hash[:bls_target]
+        else
+          @property_hash[:target] = bls_target
+        end
+
+        output = construct_bls_entry(@property_hash, bls_version)
+
+        File.open(@property_hash[:target], 'w') do |fh|
+          fh.puts(output.join("\n"))
+          fh.flush
+        end
+
+        FileUtils.chmod(0644, @property_hash[:target])
+
+        if File.exist?(legacy_target)
+          FileUtils.rm_f(legacy_target)
+
+          # Need to rebuild the full grub config if we removed a legacy target
+          grub2_mkconfig
+        end
+      end
+    else
+      if @property_hash[:destroy]
+        FileUtils.rm_f(legacy_target)
+        return
+      else
+        @property_hash[:load_16bit] = resource[:load_16bit]
+        @property_hash[:add_defaults_on_creation] = resource[:add_defaults_on_creation]
+
+        unless @property_hash[:create_output]
+          # If we have a modification request, but the target file does not exist,
+          # this means that the entry was picked up from something that is not
+          # Puppet managed and is an error.
+          unless File.exist?(legacy_target)
+            raise Puppet::Error, 'Cannot modify a stock system resource; please change your resource :name'
+          end
+        end
+
+        output = construct_grub2cfg_entry(@property_hash)
+
+        File.open(legacy_target, 'w') do |fh|
+          fh.puts(output.join("\n"))
+          fh.flush
+        end
+
+        FileUtils.chmod(0755, legacy_target)
+
+        # Need to remove the BLS config if we moved it to be legacy
+        FileUtils.rm_f(bls_target) if File.exist?(bls_target)
+
+        grub2_mkconfig
       end
     end
 
+    if @property_hash[:default_entry]
+      grub_set_default %(#{(Array(@property_hash[:submenus]) + Array(@property_hash[:name])).compact.join('>')})
+    end
+  end
+
+  private
+
+  def get_kernel(is, should, grubby_info=@grubby_info)
+    new_kernel = should
+
+    if new_kernel == ':preserve:'
+      new_kernel = is
+      if !new_kernel || new_kernel.empty?
+        new_kernel = ':default:'
+      end
+    end
+
+    if new_kernel == ':default:'
+      new_kernel = PuppetX::AugeasprovidersGrub::Util.munge_grubby_value(new_kernel, 'kernel', grubby_info)
+    end
+
+    unless new_kernel
+      raise Puppet::Error, 'Could not find a valid kernel value to set'
+    end
+
+    return new_kernel
+  end
+
+  def get_kernel_options(is, should, default_entry=@default_entry)
+    if @property_hash[:create_output] && @property_hash[:add_defaults_on_creation] && should.include?(':preserve:')
+      should << ':defaults:'
+    end
+
+    default_kernel_options = default_entry[:kernel_options]
+    if resource[:modules]
+      # We don't want to pick up any default kernel options if this is a multiboot entry.
+      default_kernel_options = {}
+    end
+
+    new_kernel_options = PuppetX::AugeasprovidersGrub::Util.munged_options(is, should, default_entry[:kernel], default_kernel_options)
+
+    old_kernel_options = PuppetX::AugeasprovidersGrub::Util.munged_options(is, ':preserve:', default_entry[:kernel], default_entry[:kernel_options])
+
+    return { :new_kernel_options => new_kernel_options, :old_kernel_options => old_kernel_options}
+  end
+
+  def get_initrd(is, should, grubby_info=@grubby_info)
+    new_initrd = should
+
+    if new_initrd == ':preserve:'
+      new_initrd = is
+      if !new_initrd || new_initrd.empty?
+        new_initrd = ':default:'
+      end
+    end
+
+    if new_initrd == ':default:'
+      new_initrd = PuppetX::AugeasprovidersGrub::Util.munge_grubby_value(new_initrd, 'initrd', grubby_info)
+    end
+
+    unless new_initrd
+      raise Puppet::Error, 'Could not find a valid initrd value to set'
+    end
+
+    return new_initrd
+  end
+
+  def construct_bls_entry(property_hash, bls_version, header_comment='### PUPPET MANAGED ###')
+    output = []
+
+    output << header_comment
+    output << "title #{property_hash[:name]}"
+    output << "version #{bls_version}"
+    output << "linux #{property_hash[:kernel]}"
+    output << "initrd #{property_hash[:initrd]}"
+    output << "options #{Array(property_hash[:kernel_options]).join(' ')}"
+    output << "id #{property_hash[:id]}-#{bls_version}"
+
+    if property_hash[:users].include?('unrestricted') || property_hash[:users].include?(:unrestricted)
+      property_hash[:users].delete(:unrestricted)
+      property_hash[:users].delete('unrestricted')
+
+      output << "grub_arg --unrestricted"
+    end
+
+    if property_hash[:users].empty?
+      output << 'grub_users $grub_users'
+    else
+      output << "grub_users #{property_hash[:users].join(' ')}"
+    end
+
+    property_hash[:args].each do |arg|
+      output << "grub_arg #{arg}"
+    end
+
+    property_hash[:classes].each do |cls|
+      output << "grub_class #{cls}"
+    end
+
+    return output
+  end
+
+  def construct_grub2cfg_entry(property_hash, header_comment='### PUPPET MANAGED ###')
     output = []
 
     output << '#!/bin/sh'
 
     # We use this to determine if we're puppet managed or not
-    output << '#### PUPPET MANAGED ####'
+    output << header_comment
     output << 'exec tail -n +3 $0'
 
     # Build the main menuentry line
-    menuentry_line = ["menuentry '#{@new_entry[:name]}'"]
+    menuentry_line = ["menuentry '#{@property_hash[:name]}'"]
 
-    if @new_entry[:classes] && !@new_entry[:classes].empty?
-      menuentry_line << @new_entry[:classes].map{|x| x = "--class #{x}"}.join(' ')
-    end
+    menuentry_line << @property_hash[:classes].map{|x| x = "--class #{x}"}.join(' ')
 
-    if @new_entry[:users] && !@new_entry[:users].empty?
-      if @new_entry[:users].map{|x| x.to_s}.include?('unrestricted')
+    unless @property_hash[:users].empty?
+      if @property_hash[:users].include?('unrestricted') || @property_hash[:users].include?(:unrestricted)
         menuentry_line << '--unrestricted'
       else
-        menuentry_line << "--users #{@new_entry[:users].join(',')}"
+        menuentry_line << "--users #{@property_hash[:users].join(',')}"
       end
     end
 
@@ -489,54 +700,64 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
     output << menuentry_line.join(' ')
     # Main menuentry line complete
 
-    output << '  load_video' if @new_entry[:load_video]
+    output << '  load_video' if @property_hash[:load_video]
 
-    output += @new_entry[:plugins].map{|x| x = %(  insmod #{x})} if @new_entry[:plugins]
+    output += @property_hash[:plugins].map{|x| x = %(  insmod #{x})} if @property_hash[:plugins]
 
-    output << %(  set root='#{@new_entry[:root]}')
+    output << %(  set root='#{@property_hash[:root]}')
 
     # Build the main kernel line
     kernel_line = []
 
     # If we have modules defined, we're in multiboot mode
-    if @new_entry[:modules] && !@new_entry[:modules].empty?
+    if @property_hash[:modules] && !@property_hash[:modules].empty?
       if File.exist?('/sys/firmware/efi')
         output << '  insmod multiboot2'
       end
 
       kernel_line << '  multiboot'
     else
-      if @new_entry[:load_16bit]
+      if @property_hash[:load_16bit]
         kernel_line << '  linux16'
       else
         kernel_line << '  linux'
       end
     end
 
-    kernel_line << @new_entry[:kernel]
-    kernel_line << @new_entry[:kernel_options]
-    output << kernel_line.compact.join(' ')
+    kernel_line << @property_hash[:kernel]
+    kernel_line << @property_hash[:kernel_options]
 
-    if @new_entry[:modules] && !@new_entry[:modules].empty?
-      @new_entry[:modules].each do |mod|
-        output << %(  module #{mod.compact.join(' ')})
+    output << kernel_line.flatten.compact.join(' ')
+
+    if @property_hash[:modules].empty?
+      if @property_hash[:load_16bit]
+        output << %(  initrd16 #{@property_hash[:initrd]})
+      else
+        output << %(  initrd #{@property_hash[:initrd]})
       end
     else
-      if @new_entry[:load_16bit]
-        output << %(  initrd16 #{@new_entry[:initrd]})
-      else
-        output << %(  initrd #{@new_entry[:initrd]})
+      @property_hash[:modules].each do |mod|
+        output << %(  module #{mod.compact.join(' ')})
       end
     end
 
     output << '}'
 
-    fh = File.open(@new_entry[:output_file], 'w')
-    fh.puts(output.join("\n"))
-    fh.flush
-    fh.close
+    return output
+  end
 
-    FileUtils.chmod(0755, @new_entry[:output_file])
+  # Run the grub2-mkconfig command on the discovered file paths deconflicting
+  # across symlinks
+  def grub2_mkconfig(cfg_paths=['/etc/grub2.cfg', '/etc/grub2-efi.cfg', '/boot/grub/grub.cfg', '/boot/grub2/grub.cfg'])
+    tgt_files = []
+
+    cfg_paths.each do |path|
+      begin
+        tgt_files << File.realpath(path)
+      rescue
+        next
+      end
+    end
 
     os_info = Facter.value(:os)
     if os_info
@@ -560,10 +781,14 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
     }
     fail("Cannot find grub.cfg location to use with #{command(:mkconfig)}") unless cfg
 
-    mkconfig "-o", cfg
+    # This takes a while to run
+    mkconfig_output = mkconfig
 
-    if @new_entry[:default_entry]
-      grub_set_default %(#{(Array(@new_entry[:submenus]) + Array(@new_entry[:name])).compact.join('>')})
+    cfg_paths.uniq.each do |cfg_path|
+      File.open(cfg_path, 'w') do |fh|
+        fh.puts(mkconfig_output)
+        fh.flush
+      end
     end
   end
 end

--- a/lib/puppet/provider/grub_menuentry/grub2.rb
+++ b/lib/puppet/provider/grub_menuentry/grub2.rb
@@ -310,16 +310,17 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
 
     @property_hash[:target] = resource[:target] if resource[:target]
     @property_hash[:add_defaults_on_creation] = resource[:add_defaults_on_creation]
+    @property_hash[:classes] ||= resource[:classes] || []
 
     @property_hash[:bls] = @bls_system && (@property_hash[:bls] || (@property_hash[:bls].nil? && (resource[:bls].nil? || resource[:bls])))
 
     # BLS and non-BLS systems must be treated differently
     if @property_hash[:bls] || resource[:bls]
       @property_hash[:args] ||= []
-    else @property_hash[:bls]
+    else
       @property_hash[:load_16bit] ||= resource[:load_16bit].nil? ? true : resource[:load_16bit]
       @property_hash[:load_video] ||= resource[:load_video].nil? ? true : resource[:load_video]
-      @property_hash[:plugins] ||= resource[:plugins].nil? ? true : resource[:plugins]
+      @property_hash[:plugins] ||= resource[:plugins].nil? ? ['gzio','part_msdos','xfs','ext2'] : resource[:plugins]
     end
 
     retval = @property_hash[:name] == resource[:name]
@@ -353,7 +354,7 @@ Puppet::Type.type(:grub_menuentry).provide(:grub2) do
       @property_hash[:root]       = resource[:root]
       @property_hash[:load_16bit] = resource[:load_16bit]
       @property_hash[:load_video] = resource[:load_video]
-      @property_hash[:plugins]    = resource[:plugins]
+      @property_hash[:plugins]  ||= resource[:plugins].nil? ? ['gzio','part_msdos','xfs','ext2'] : resource[:plugins]
     end
   end
 

--- a/lib/puppet/type/grub_menuentry.rb
+++ b/lib/puppet/type/grub_menuentry.rb
@@ -8,6 +8,9 @@
 # Based on work by Dominic Cleal
 
 Puppet::Type.newtype(:grub_menuentry) do
+  require 'puppet/parameter/boolean'
+  require 'puppet/property/boolean'
+
   @doc = <<-EOM
     Manages menu entries in the GRUB and GRUB2 systems.
 
@@ -38,17 +41,7 @@ Puppet::Type.newtype(:grub_menuentry) do
     EOM
   end
 
-  newparam(:load_16bit, :boolean => true, :required_featurees => %w(grub2)) do
-    desc <<-EOM
-      If set, ensure that linux16 and initrd16 are used for the kernel entries.
-    EOM
-
-    newvalues(:true, :false)
-
-    defaultto :true
-  end
-
-  newparam(:add_defaults_on_creation, :boolean => true) do
+  newparam(:add_defaults_on_creation, :parent => Puppet::Parameter::Boolean) do
     desc <<-EOM
       If set, when using the ':preserve:' option in `kernel_options` or
       `modules` will add the system defaults if the entry is being first
@@ -70,12 +63,12 @@ Puppet::Type.newtype(:grub_menuentry) do
     newvalues(/\(.*\)/)
   end
 
-  newproperty(:default_entry, :boolean => true) do
+  newproperty(:default_entry, :parent => Puppet::Property::Boolean) do
     desc <<-EOM
       If set, make this menu entry the default entry.
 
-      If more than one of these is defined across all :menuentry resources,
-      this is an error.
+      If more than one of these is set to `true` across all :menuentry
+      resources, this is an error.
 
       In GRUB2, there is no real guarantee that this will stick since entries
       further down the line may have custom scripts which alter the default.
@@ -84,8 +77,6 @@ Puppet::Type.newtype(:grub_menuentry) do
             type to set the system default.
     EOM
     newvalues(:true, :false)
-
-    defaultto :false
   end
 
   newproperty(:kernel) do
@@ -219,20 +210,7 @@ Puppet::Type.newtype(:grub_menuentry) do
     end
   end
 
-  # GRUB Legacy only properties
-=begin
-# This currently does not function properly as the 'lock' entry is misaligned within an entry.
-  newproperty(:lock, :boolean => true, :required_features => %w(grub)) do
-    desc <<-EOM
-      In Legacy GRUB, having this set will add a 'lock' entry to the menuentry.
-    EOM
-    newvalues(:true, :false)
-
-    defaultto :false
-  end
-=end
-
-  newproperty(:makeactive, :boolean => true, :required_features => %w(grub)) do
+  newproperty(:makeactive, :parent => Puppet::Property::Boolean, :required_features => %w(grub)) do
     desc <<-EOM
       In Legacy GRUB, having this set will add a 'makeactive' entry to the menuentry.
     EOM
@@ -242,6 +220,16 @@ Puppet::Type.newtype(:grub_menuentry) do
   end
 
   # GRUB2 only properties
+  newproperty(:bls, :parent => Puppet::Property::Boolean, :required_features => %w(grub2)) do
+    desc <<-EOM
+      Explicitly enable, or disable, BLS support for this resource.
+
+      Has on effect on systems that are not BLS enabled.
+    EOM
+
+    newvalues(:true, :false)
+  end
+
   newproperty(:classes, :array_matching => :all, :required_features => %w(grub2)) do
     desc <<-EOM
       Add this Array of classes to the menuentry.
@@ -257,25 +245,44 @@ Puppet::Type.newtype(:grub_menuentry) do
     defaultto [:unrestricted]
 
     munge do |value|
-      value = Array(value).map{|x| x.to_s.strip.split(/\s|,|;|\||&/)}.flatten.join(',')
+      value = value.to_s.strip.split(/\s|,|;|\||&/)
+    end
+
+    def should
+      values = super.flatten
+      values.include?('unrestricted') ? [:unrestricted] : values
+    end
+
+    def insync?(is)
+      is.sort == should.sort
     end
   end
 
-  newproperty(:load_video, :boolean => true, :required_features => %w(grub2)) do
+  newproperty(:load_16bit, :parent => Puppet::Property::Boolean, :required_featurees => %w(grub2)) do
+    desc <<-EOM
+      If set, ensure that `linux16` and `initrd16` are used for the kernel entries.
+
+      Will default to `true` unless the entry is a BLS entry.
+    EOM
+
+    newvalues(:true, :false)
+  end
+
+  newproperty(:load_video, :parent => Puppet::Property::Boolean, :required_features => %w(grub2)) do
     desc <<-EOM
       If true, add the `load_video` command to the menuentry.
+
+      Will default to `true` unless the entry is a BLS entry.
     EOM
     newvalues(:true, :false)
-
-    defaultto :true
   end
 
   newproperty(:plugins, :array_matching => :all, :required_features => %w(grub2)) do
     desc <<-EOM
       An Array of plugins that should be included in this menuentry.
-    EOM
 
-    defaultto ['gzio','part_msdos','xfs','ext2']
+      Will default to `['gzio','part_msdos','xfs','ext2']` unless the entry is a BLS entry.
+    EOM
   end
 
   # Autorequires

--- a/lib/puppet/type/grub_menuentry.rb
+++ b/lib/puppet/type/grub_menuentry.rb
@@ -63,7 +63,7 @@ Puppet::Type.newtype(:grub_menuentry) do
     newvalues(/\(.*\)/)
   end
 
-  newproperty(:default_entry, :parent => Puppet::Property::Boolean) do
+  newproperty(:default_entry) do
     desc <<-EOM
       If set, make this menu entry the default entry.
 
@@ -77,6 +77,16 @@ Puppet::Type.newtype(:grub_menuentry) do
             type to set the system default.
     EOM
     newvalues(:true, :false)
+
+    def should
+      return nil unless defined?(@should)
+
+      (@should - [true,:true]).empty?
+    end
+
+    def insync?(is)
+      is == should
+    end
   end
 
   newproperty(:kernel) do
@@ -210,17 +220,27 @@ Puppet::Type.newtype(:grub_menuentry) do
     end
   end
 
-  newproperty(:makeactive, :parent => Puppet::Property::Boolean, :required_features => %w(grub)) do
+  newproperty(:makeactive, :required_features => %w(grub)) do
     desc <<-EOM
       In Legacy GRUB, having this set will add a 'makeactive' entry to the menuentry.
     EOM
     newvalues(:true, :false)
 
     defaultto :false
+
+    def should
+      return nil unless defined?(@should)
+
+      (@should - [true,:true]).empty?
+    end
+
+    def insync?(is)
+      is == should
+    end
   end
 
   # GRUB2 only properties
-  newproperty(:bls, :parent => Puppet::Property::Boolean, :required_features => %w(grub2)) do
+  newproperty(:bls, :required_features => %w(grub2)) do
     desc <<-EOM
       Explicitly enable, or disable, BLS support for this resource.
 
@@ -228,6 +248,16 @@ Puppet::Type.newtype(:grub_menuentry) do
     EOM
 
     newvalues(:true, :false)
+
+    def should
+      return nil unless defined?(@should)
+
+      (@should - [true,:true]).empty?
+    end
+
+    def insync?(is)
+      is == should
+    end
   end
 
   newproperty(:classes, :array_matching => :all, :required_features => %w(grub2)) do
@@ -258,7 +288,7 @@ Puppet::Type.newtype(:grub_menuentry) do
     end
   end
 
-  newproperty(:load_16bit, :parent => Puppet::Property::Boolean, :required_featurees => %w(grub2)) do
+  newproperty(:load_16bit, :required_featurees => %w(grub2)) do
     desc <<-EOM
       If set, ensure that `linux16` and `initrd16` are used for the kernel entries.
 
@@ -266,15 +296,35 @@ Puppet::Type.newtype(:grub_menuentry) do
     EOM
 
     newvalues(:true, :false)
+
+    def should
+      return nil unless defined?(@should)
+
+      (@should - [true,:true]).empty?
+    end
+
+    def insync?(is)
+      is == should
+    end
   end
 
-  newproperty(:load_video, :parent => Puppet::Property::Boolean, :required_features => %w(grub2)) do
+  newproperty(:load_video, :required_features => %w(grub2)) do
     desc <<-EOM
       If true, add the `load_video` command to the menuentry.
 
       Will default to `true` unless the entry is a BLS entry.
     EOM
     newvalues(:true, :false)
+
+    def should
+      return nil unless defined?(@should)
+
+      (@should - [true,:true]).empty?
+    end
+
+    def insync?(is)
+      is == should
+    end
   end
 
   newproperty(:plugins, :array_matching => :all, :required_features => %w(grub2)) do

--- a/spec/acceptance/10_grub_config_spec.rb
+++ b/spec/acceptance/10_grub_config_spec.rb
@@ -76,7 +76,7 @@ describe 'Global Config Tests' do
       end
 
       it 'should have a timeout of 1' do
-        on(host, %(grep 'GRUB_TIMEOUT="1"' /etc/default/grub))
+        on(host, %(grep 'GRUB_TIMEOUT="\\?1"\\?' /etc/default/grub))
         on(host, %(grep 'timeout=1' /boot/grub2/grub.cfg))
       end
     end

--- a/spec/acceptance/10_grub_menuentry_spec.rb
+++ b/spec/acceptance/10_grub_menuentry_spec.rb
@@ -67,8 +67,8 @@ describe 'GRUB Menuentry Tests' do
           result_hash[$1.strip] = $2.strip
         end
 
-        expect(result_hash['title']).to eq('Standard')
-        expect(result_hash['args']).to match(/trogdor=BURNINATE/)
+        expect(result_hash['title'].delete('"')).to eq('Standard')
+        expect(result_hash['args'].delete('"')).to include('trogdor=BURNINATE')
       end
 
       it 'should activate on reboot' do

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,24 +1,26 @@
 HOSTS:
-  server:
+  el7:
     roles:
-      - server
       - default
-      - master
       - grub2
     platform:   el-7-x86_64
-    box:        puppetlabs/centos-7.0-64-nocm
-    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
+    box:        generic/centos7
     hypervisor: vagrant
 
-  client:
+  el8:
     roles:
-      - agent
-      - client
-      - grub
-    platform:   el-6-x86_64
-    box:        puppetlabs/centos-6.6-64-nocm
-    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+      - grub2
+    platform:   el-8-x86_64
+    box:        generic/centos8
     hypervisor: vagrant
+
+# el6:
+#   roles:
+#     - grub
+#   platform:   el-6-x86_64
+#   box:        puppetlabs/centos-6.6-64-nocm
+#   box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
+#   hypervisor: vagrant
 
 CONFIG:
   log_level: verbose


### PR DESCRIPTION
* Adds BLS support which should fix issues on EL8 and Fedora 30
* Fixed the issue with duplicating kernel options while debugging
* Updates both non-EFI and EFI paths

Closes #49
Closes #38
Closes #37