### PR TITLE
Call grub2-mkconfig on all targets

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -164,7 +164,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
       end
     end
 
-    cfg = nil
+    cfg = []
     [
       "/etc/grub2-efi.cfg",
       # Handle the standard EFI naming convention
@@ -175,14 +175,15 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
       if FileTest.file?(c) || ( FileTest.symlink?(c) &&
           FileTest.directory?(File.dirname(File.absolute_path(File.readlink(c)))) )
 
-        cfg = c
-        break
+        cfg.push(c)
 
       end
     }
     fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg
 
     super
-    mkconfig "-o", cfg
+    cfg.each {|c|
+      mkconfig "-o", c
+    }
   end
 end

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -175,7 +175,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
       if FileTest.file?(c) || ( FileTest.symlink?(c) &&
           FileTest.directory?(File.dirname(File.absolute_path(File.readlink(c)))) )
 
-        cfg.push(c)
+        cfg << c
 
       end
     }

--- a/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
@@ -38,6 +38,7 @@ describe provider_class do
       FileTest.stubs(:exist?).with(path).returns true
       FileTest.stubs(:executable?).with(path).returns true
     end
+    FileTest.stubs(:file?).with('/etc/grub2-efi.cfg').returns true
     FileTest.stubs(:file?).with('/boot/grub2/grub.cfg').returns true
     FileTest.stubs(:exist?).with('/etc/default/grub').returns true
   end
@@ -70,6 +71,7 @@ describe provider_class do
     describe "when creating entries" do
       before :each do
         provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg")
+        provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg")
       end
 
       it "should create no-value entries" do
@@ -214,6 +216,7 @@ describe provider_class do
 
     it "should delete entries" do
       provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg")
+      provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg")
 
       apply!(Puppet::Type.type(:kernel_parameter).new(
         :name     => "divider",
@@ -243,6 +246,7 @@ describe provider_class do
 
       it "should change existing values" do
         provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg")
+        provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg")
         apply!(Puppet::Type.type(:kernel_parameter).new(
           :name     => "elevator",
           :ensure   => :present,
@@ -268,6 +272,7 @@ describe provider_class do
 
       it "should add value to entry" do
         provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg")
+        provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg")
         apply!(Puppet::Type.type(:kernel_parameter).new(
           :name     => "quiet",
           :ensure   => :present,
@@ -293,6 +298,7 @@ describe provider_class do
 
       it "should add and remove entries for multiple values" do
         provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg").times(2)
+        provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg").times(2)
 
         # Add multiple entries
         apply!(Puppet::Type.type(:kernel_parameter).new(


### PR DESCRIPTION
Currently grub2-mkconfig is called on the first file
that exists from.

```
"/etc/grub2-efi.cfg",
"/boot/efi/EFI/#{os_name.downcase}/grub.cfg",
"/boot/grub2/grub.cfg",
"/boot/grub/grub.cfg"
```

So on a CentOS 7 system `grub2-efi.cfg` is generated only
from `/etc/default/grub`.

With an EFI system configured for bios boot the
`/boot/grub2/grub.cfg` is the important one so
 `kernel_parameter` updates are not applied.

Taking inspiration from [new-kernel-pkg](https://github.com/rhboot/grubby/blob/master/new-kernel-pkg)
to see what happens on kernel upgrade `grubby` is called for each of
these files that exists so emulating this logic make sense.

Fixes #4