### PR TITLE
Fix mkconfig calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,19 @@
 language: ruby
-sudo: required
+version: ~> 1.0
+os: linux
+sudo: false
+bundler_args: --without development system_tests --path vendor
+
+addons:
+  apt:
+    packages:
+      # provides unbuffer
+      - expect-dev
+      - libaugeas-dev
+      - augeas-tools
+
 rvm:
-  - 2.4.4
+  - 2.5.8
 notifications:
   email:
    - raphael.pinson@camptocamp.com
@@ -11,15 +23,13 @@ env:
   - PUPPET=5.5 RUBY_AUGEAS=0.5 FORGE_PUBLISH=true
   # Test latest Puppet version
   - PUPPET=6 RUBY_AUGEAS=0.5
-
+  - PUPPET=7 RUBY_AUGEAS=0.5
 
 matrix:
   fast_finish: true
 
-install:
-  - "travis_retry ./.travis.sh"
 script:
-  - AUGEAS_LENS_LIB=lib/augeas/lenses:augeas/lenses bundle exec rake
+  - AUGEAS_LENS_LIB=lib/augeas/lenses:augeas/lenses travis_wait 45 unbuffer bundle exec rake
   # Do not include the augeas/ directory in the deployed module
   - rm -rf augeas/
 deploy:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ normal.
 
 See [Puppet/Augeas pre-requisites](http://docs.puppetlabs.com/guides/augeas.html#pre-requisites).
 
+**WARNING** Your system must be able to run the grub mkconfig scripts with BLS
+support if you are on a systen that uses BLS!
+
 ## Installing
 
 On Puppet 2.7.14+, the module can be installed easily ([documentation](http://docs.puppetlabs.com/puppet/latest/reference/modules_installing.html)):

--- a/lib/puppet/provider/grub_config/grub2.rb
+++ b/lib/puppet/provider/grub_config/grub2.rb
@@ -78,29 +78,9 @@ Puppet::Type.type(:grub_config).provide(:grub2, :parent => Puppet::Type.type(:au
   end
 
   def flush
-    os_info = Facter.value(:os)
-    if os_info
-      os_name = Facter.value(:os)['name']
-    else
-      # Support for old versions of Facter
-      unless os_name
-        os_name = Facter.value(:operatingsystem)
-      end
-    end
-
-    cfg = nil
-    [
-      "/etc/grub2-efi.cfg",
-      # Handle the standard EFI naming convention
-      "/boot/efi/EFI/#{os_name.downcase}/grub.cfg",
-      "/boot/grub2/grub.cfg",
-      "/boot/grub/grub.cfg"
-    ].each {|c|
-      cfg = c if FileTest.file? c
-    }
-    fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg
-
     super
-    mkconfig "-o", cfg
+
+    require 'puppetx/augeasproviders_grub/util'
+    PuppetX::AugeasprovidersGrub::Util.grub2_mkconfig(mkconfig)
   end
 end

--- a/lib/puppet/provider/grub_menuentry/grub.rb
+++ b/lib/puppet/provider/grub_menuentry/grub.rb
@@ -79,7 +79,7 @@ Puppet::Type.type(:grub_menuentry).provide(:grub, :parent => Puppet::Type.type(:
   end
 
   def self.instances
-    require 'puppetx/augeasproviders_grub/menuentry'
+    require 'puppetx/augeasproviders_grub/util'
 
     resources = []
 
@@ -132,7 +132,7 @@ Puppet::Type.type(:grub_menuentry).provide(:grub, :parent => Puppet::Type.type(:
 
 
   def initialize(*args)
-    require 'puppetx/augeasproviders_grub/menuentry'
+    require 'puppetx/augeasproviders_grub/util'
 
     @grubby_info = {}
     begin

--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -154,36 +154,9 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, :parent => Puppet::Type.typ
   end
 
   def flush
-    os_info = Facter.value(:os)
-    if os_info
-      os_name = Facter.value(:os)['name']
-    else
-      # Support for old versions of Facter
-      unless os_name
-        os_name = Facter.value(:operatingsystem)
-      end
-    end
-
-    cfg = []
-    [
-      "/etc/grub2-efi.cfg",
-      # Handle the standard EFI naming convention
-      "/boot/efi/EFI/#{os_name.downcase}/grub.cfg",
-      "/boot/grub2/grub.cfg",
-      "/boot/grub/grub.cfg"
-    ].each {|c|
-      if FileTest.file?(c) || ( FileTest.symlink?(c) &&
-          FileTest.directory?(File.dirname(File.absolute_path(File.readlink(c)))) )
-
-        cfg << c
-
-      end
-    }
-    fail("Cannot find grub.cfg location to use with grub-mkconfig") unless cfg
-
     super
-    cfg.each {|c|
-      mkconfig "-o", c
-    }
+
+    require 'puppetx/augeasproviders_grub/util'
+    PuppetX::AugeasprovidersGrub::Util.grub2_mkconfig(mkconfig)
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -36,28 +36,31 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8.1"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8.1"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8.1"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 5.0.0 < 8.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -14,16 +14,9 @@ HOSTS:
     box:        generic/centos8
     hypervisor: vagrant
 
-  el6:
-    roles:
-      - grub
-    platform:   el-6-x86_64
-    box:        puppetlabs/centos-6.6-64-nocm
-    box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
-    hypervisor: vagrant
-
 CONFIG:
   log_level: verbose
   type:      aio
   vagrant_memsize: 256
+  puppet_collection: puppet6
   ## vb_gui: true

--- a/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
@@ -41,6 +41,9 @@ describe provider_class do
     FileTest.stubs(:file?).with('/etc/grub2-efi.cfg').returns true
     FileTest.stubs(:file?).with('/boot/grub2/grub.cfg').returns true
     FileTest.stubs(:exist?).with('/etc/default/grub').returns true
+
+    require 'puppetx/augeasproviders_grub/util'
+    PuppetX::AugeasprovidersGrub::Util.stubs(:grub2_cfg_paths).returns([ '/dev/null' ])
   end
 
   context "with full file" do
@@ -70,8 +73,7 @@ describe provider_class do
 
     describe "when creating entries" do
       before :each do
-        provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg")
-        provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg")
+        provider_class.any_instance.expects(:mkconfig).returns('OK')
       end
 
       it "should create no-value entries" do
@@ -215,8 +217,7 @@ describe provider_class do
     end
 
     it "should delete entries" do
-      provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg")
-      provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg")
+      provider_class.any_instance.expects(:mkconfig).returns('OK')
 
       apply!(Puppet::Type.type(:kernel_parameter).new(
         :name     => "divider",
@@ -245,8 +246,7 @@ describe provider_class do
       end
 
       it "should change existing values" do
-        provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg")
-        provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg")
+        provider_class.any_instance.expects(:mkconfig).returns('OK')
         apply!(Puppet::Type.type(:kernel_parameter).new(
           :name     => "elevator",
           :ensure   => :present,
@@ -271,8 +271,7 @@ describe provider_class do
       end
 
       it "should add value to entry" do
-        provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg")
-        provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg")
+        provider_class.any_instance.expects(:mkconfig).returns('OK')
         apply!(Puppet::Type.type(:kernel_parameter).new(
           :name     => "quiet",
           :ensure   => :present,
@@ -297,8 +296,8 @@ describe provider_class do
       end
 
       it "should add and remove entries for multiple values" do
-        provider_class.any_instance.expects(:mkconfig).with("-o", "/boot/grub2/grub.cfg").times(2)
-        provider_class.any_instance.expects(:mkconfig).with("-o", "/etc/grub2-efi.cfg").times(2)
+        # This will run once for each parameter resource
+        provider_class.any_instance.expects(:mkconfig).returns('OK').twice
 
         # Add multiple entries
         apply!(Puppet::Type.type(:kernel_parameter).new(


### PR DESCRIPTION
Fixed:
  * Moved the puppetx/augeasproviders_grub/menuentry.rb file to util.rb
    to match the module name
  * Modified all `flush` functions to call the 'global update' mkconfig
    which was added as `PuppetX::AugeasprovidersGrub::Util.mkconfig`
  * Removed EL6 from the beaker tests since the OS is no longer
    supported by the vendor and fails to run

Added:
  * Puppet 7 support
  * EL8 support

Closes #63