### PR TITLE
can alter any or all sections of /etc/default/grub by using a Composite namevar

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ Only recovery mode boots (unsupported with GRUB 2):
       bootmode => "recovery",
     }
 
+#### manage parameter on multiple boot types
+
+    kernel_parameter { 'quiet:all':
+      ensure => absent,
+    }
+    kernel_parameter { 'quiet:recovery':
+      ensure => present,
+    }
+
 #### delete entry
 
     kernel_parameter { "rhgb":

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -402,6 +402,8 @@ The following parameters are available in the `kernel_parameter` type.
 
 Valid values: `all`, `default`, `normal`, `recovery`
 
+namevar
+
 Boot mode(s) to apply the parameter to.  Either 'all' (default) to use the parameter on all boots (normal and recovery
 mode), 'default' for just the default boot entry, 'normal' for just normal boots or 'recovery' for just recovery boots.
 

--- a/lib/puppet/type/kernel_parameter.rb
+++ b/lib/puppet/type/kernel_parameter.rb
@@ -29,6 +29,8 @@ Puppet::Type.newtype(:kernel_parameter) do
   newparam(:bootmode) do
     desc "Boot mode(s) to apply the parameter to.  Either 'all' (default) to use the parameter on all boots (normal and recovery mode), 'default' for just the default boot entry, 'normal' for just normal boots or 'recovery' for just recovery boots."
 
+    isnamevar
+
     newvalues :all, :default, :normal, :recovery
 
     defaultto :all
@@ -36,5 +38,26 @@ Puppet::Type.newtype(:kernel_parameter) do
 
   autorequire(:file) do
     self[:target]
+  end
+
+  # title_patterns method for mapping titles to namevars for supporting
+  # composite namevars.
+  # https://github.com/puppetlabs/puppetlabs-java_ks/blob/5bc34745a6f86e0c4af495e0ad3559c82d57873a/lib/puppet/type/java_ks.rb#L209
+  def self.title_patterns
+    [
+      [
+        %r{^([^:]+)$},
+        [
+          [:name],
+        ],
+      ],
+      [
+        %r{^(.*):(.*)$},
+        [
+          [:name],
+          [:bootmode],
+        ],
+      ],
+    ]
   end
 end

--- a/lib/puppet/type/kernel_parameter.rb
+++ b/lib/puppet/type/kernel_parameter.rb
@@ -46,7 +46,7 @@ Puppet::Type.newtype(:kernel_parameter) do
   def self.title_patterns
     [
       [
-        %r{^([^:]+)$},
+        %r{\A([^:]+)\z},
         [
           [:name],
         ],

--- a/lib/puppet/type/kernel_parameter.rb
+++ b/lib/puppet/type/kernel_parameter.rb
@@ -52,7 +52,7 @@ Puppet::Type.newtype(:kernel_parameter) do
         ],
       ],
       [
-        %r{^(.*):(.*)$},
+        %r{^([^:]+):([^:]+)$},
         [
           [:name],
           [:bootmode],

--- a/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
@@ -238,6 +238,30 @@ describe provider_class do
       ')
     end
 
+    it 'deletes specific entries' do
+      allow_any_instance_of(provider_class).to receive(:mkconfig).and_return('OK')
+
+      apply!(Puppet::Type.type(:kernel_parameter).new(
+               title: 'rhgb:normal',
+               ensure: 'absent',
+               target: target,
+               provider: 'grub2'
+             ))
+
+      augparse_filter(target, LENS, FILTER, '
+        { "GRUB_CMDLINE_LINUX"
+          { "quote" = "\"" }
+          { "value" = "quiet" }
+          { "value" = "elevator=noop" }
+          { "value" = "divider=10" }
+        }
+        { "GRUB_CMDLINE_LINUX_DEFAULT"
+          { "quote" = "\"" }
+          { "value" = "nohz=on" }
+        }
+      ')
+    end
+
     describe 'when modifying values' do
       before do
         allow_any_instance_of(provider_class).to receive(:create).and_raise('nope')

--- a/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
@@ -262,6 +262,32 @@ describe provider_class do
       ')
     end
 
+    it 'creates specific entries' do
+      allow_any_instance_of(provider_class).to receive(:mkconfig).and_return('OK')
+
+      apply!(Puppet::Type.type(:kernel_parameter).new(
+               title: 'splash:default',
+               ensure: 'present',
+               target: target,
+               provider: 'grub2'
+             ))
+
+      augparse_filter(target, LENS, FILTER, '
+        { "GRUB_CMDLINE_LINUX"
+          { "quote" = "\"" }
+          { "value" = "quiet" }
+          { "value" = "elevator=noop" }
+          { "value" = "divider=10" }
+        }
+        { "GRUB_CMDLINE_LINUX_DEFAULT"
+          { "quote" = "\"" }
+          { "value" = "rhgb" }
+          { "value" = "nohz=on" }
+          { "value" = "splash" }
+        }
+      ')
+    end
+
     describe 'when modifying values' do
       before do
         allow_any_instance_of(provider_class).to receive(:create).and_raise('nope')


### PR DESCRIPTION
#### Pull Request (PR) description
feat: augeasprovider_grub can insert values into any or all sections

extends title to a composite namevar.
Examples provided.
Tests included.

#### This Pull Request (PR) fixes the following issues
https://github.com/voxpupuli/puppet-augeasproviders_grub/issues/23
https://github.com/voxpupuli/puppet-augeasproviders_grub/issues/52
https://github.com/voxpupuli/puppet-augeasproviders_grub/issues/94
