### PR TITLE
Fix `resources { purge => true }` for `GRUB_CMDLINE_LINUX_DEFAULT` params

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -50,16 +50,20 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
     super + 1
   end
 
+  # Composite title for Type.instances to preserve bootmode in resource identity.
+  def title
+    "#{@property_hash[:name]}:#{@property_hash[:bootmode]}"
+  end
+
   def self.instances
     augopen do |aug|
       resources = []
 
-      # Params are nicely separated, but no recovery-only setting (hard-coded)
+      # 'normal' and 'default' both map to GRUB_CMDLINE_LINUX_DEFAULT, so only
+      # emit 'default' to avoid duplicate resources for the same grub variable.
       sections = { 'all' => 'GRUB_CMDLINE_LINUX',
-                   'normal' => 'GRUB_CMDLINE_LINUX_DEFAULT',
                    'default' => 'GRUB_CMDLINE_LINUX_DEFAULT' }
-      sections.keys.sort.each do |bootmode|
-        key = sections[bootmode]
+      sections.each do |bootmode, key|
         # Get all unique param names
         params = aug.match("$target/#{key}/value").map do |pp|
           aug.get(pp).split('=')[0]

--- a/lib/puppet/type/kernel_parameter.rb
+++ b/lib/puppet/type/kernel_parameter.rb
@@ -37,6 +37,16 @@ Puppet::Type.newtype(:kernel_parameter) do
     defaultto :all
   end
 
+  # Composite title for `resources { purge => true }` support.
+  # See: https://github.com/puppetlabs/puppetlabs-sshkeys_core/pull/32
+  def name
+    # 'normal' and 'default' are identical in GRUB2 (both map to
+    # GRUB_CMDLINE_LINUX_DEFAULT), so normalize to avoid purge churn.
+    mode = self[:bootmode].to_s == 'normal' ? 'default' : self[:bootmode]
+    "#{self[:name]}:#{mode}"
+  end
+  alias_method :title, :name
+
   autorequire(:file) do
     self[:target]
   end

--- a/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
@@ -59,14 +59,12 @@ describe provider_class do
         }
       end
 
-      expect(inst.size).to eq 7
+      expect(inst.size).to eq 5
       expect(inst[0]).to include(name: 'quiet', ensure: :present, value: :absent, bootmode: 'all')
       expect(inst[1]).to include(name: 'elevator', ensure: :present, value: 'noop', bootmode: 'all')
       expect(inst[2]).to include(name: 'divider', ensure: :present, value: '10', bootmode: 'all')
       expect(inst[3]).to include(name: 'rhgb', ensure: :present, value: :absent, bootmode: 'default')
       expect(inst[4]).to include(name: 'nohz', ensure: :present, value: 'on', bootmode: 'default')
-      expect(inst[5]).to include(name: 'rhgb', ensure: :present, value: :absent, bootmode: 'normal')
-      expect(inst[6]).to include(name: 'nohz', ensure: :present, value: 'on', bootmode: 'normal')
     end
 
     describe 'when creating entries' do


### PR DESCRIPTION
#### Pull Request (PR) description

Without this fix, `resources { purge => true }` silently skips kernel parameters in `GRUB_CMDLINE_LINUX_DEFAULT` because the bootmode is lost during `Type.instances` resource creation. The purge-generated absent resources fall back to the default bootmode `all`, which looks in `GRUB_CMDLINE_LINUX` instead of `GRUB_CMDLINE_LINUX_DEFAULT`. This is the same class of bug fixed in sshkeys_core (PUP-10510).

I made these changes for our own production setup. `purge => true` now correctly removes kernel parameters from the `_DEFAULT` section, as well as the other one.

Changes:
- Add composite title (`name:bootmode`) via type-level `name`/`title` override so catalog resources and provider instances share the same ref format
- Add `title` method to provider so `Type.instances` preserves bootmode
- Deduplicate `normal` from `instances` since it maps to the same grub variable as `default` in GRUB2
- Normalize `normal` to `default` in the composite title to prevent purge churn between the two equivalent bootmodes

The test change reflects the deduplication: `instances` previously returned each `GRUB_CMDLINE_LINUX_DEFAULT` param twice (once as `default`, once as `normal`) since both bootmodes map to the same grub variable. With composite titles, these duplicates would produce two resources with the same normalized title, causing a conflict. The test now expects 5 instances instead of 7.

Existing code using `bootmode => 'normal'` continues to work - the `section` method still handles it, and the type-level `name` method normalizes the title so it matches correctly.

#### This Pull Request (PR) fixes the following issues

n/a
