### PR TITLE
special handling of dot in RegEx #124

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -15,7 +15,15 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
   lens { 'Shellvars_list.lns' }
 
   resource_path do |resource|
-    "$target/#{section(resource)}/value[.=~regexp('^#{resource[:name]}(=.*)?$')]"
+    # https://github.com/voxpupuli/puppet-augeasproviders_grub/issues/124
+    # :name is treated as RegEx
+    # ipv6.disable is a very special case. We do not want '.' to be treated as RegEx.
+    # as of 2026, the dot '.' is the only RegEx-special character allowed in GRUB_CMDLINE_LINUX
+    # we will escape all dots, unless they are preceded by backspace
+    # dont blame this regex on me, blame it on rubocop
+    # gsub( %r@   (?<!\\)   \.   @x , '\.' )
+    regexescape = resource[:name].gsub(%r{(?<!\\)\.}, '\.')
+    "$target/#{section(resource)}/value[.=~regexp('^#{regexescape}(=.*)?$')]"
   end
 
   def self.mkconfig_path

--- a/spec/acceptance/00_kernel_parameter_spec.rb
+++ b/spec/acceptance/00_kernel_parameter_spec.rb
@@ -19,7 +19,29 @@ describe 'Kernel Parameter Tests' do
           value    => '1',
           bootmode => 'normal'
         }),
-      test: %(grep -q "audit=1" /proc/cmdline),
+      test: %(grep -q "audit=1" /proc/cmdline)
+    },
+    insert_ipv6: {
+      manifest: %(
+        kernel_parameter { 'ipv6.enable':
+          value => '1',
+          ensure => 'present',
+        }
+        kernel_parameter { 'ipv6_enable':
+          value => '1',
+          ensure => 'present',
+        }
+      ),
+      test: 'grep -q ipv6\.enable=1 /proc/commandline '
+    },
+    remove_ignoring_regex: {
+      manifest: %(
+        kernel_parameter { 'ipv6.enable':
+          value => '1',
+          ensure => 'absent',
+        }
+      ),
+      test: 'grep -q ipv6_enable=1 /proc/commandline && grep -vq ipv6\.enable=1 /proc/commandline'
     },
   }
 

--- a/spec/acceptance/00_kernel_parameter_spec.rb
+++ b/spec/acceptance/00_kernel_parameter_spec.rb
@@ -19,7 +19,7 @@ describe 'Kernel Parameter Tests' do
           value    => '1',
           bootmode => 'normal'
         }),
-      test: %(grep -q "audit=1" /proc/cmdline)
+      test: %(grep -q "audit=1" /proc/cmdline),
     },
     insert_ipv6: {
       manifest: %(
@@ -32,7 +32,7 @@ describe 'Kernel Parameter Tests' do
           ensure => 'present',
         }
       ),
-      test: 'grep -q ipv6\.enable=1 /proc/commandline '
+      test: 'grep -q ipv6\.enable=1 /proc/commandline ',
     },
     remove_ignoring_regex: {
       manifest: %(
@@ -41,7 +41,7 @@ describe 'Kernel Parameter Tests' do
           ensure => 'absent',
         }
       ),
-      test: 'grep -q ipv6_enable=1 /proc/commandline && grep -vq ipv6\.enable=1 /proc/commandline'
+      test: 'grep -q ipv6_enable=1 /proc/commandline && grep -vq ipv6\.enable=1 /proc/commandline',
     },
   }
 


### PR DESCRIPTION
`kernel_parameter { 'ipv6.disable:all' }` gets treated as RegEx. This PR escapes the dot.