### PR TITLE
fix: don't pass --update-bls-cmdline on Amazon Linux and Fedora

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -39,9 +39,10 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
   def self.mkconfig_cmdline
     os = Facter.value(:os)
     # BLS cmdline option is only needed on RHEL 9.3+
-    # Fedora and Amazon Linux lack support and are excluded
-    # since they don't have a release with major version 9
+    # Fedora and Amazon Linux lack support and are excluded by name, since
+    # their release majors (42, 2023, ...) would otherwise satisfy the >= 10 test
     needs_bls_cmdline = os.is_a?(Hash) && os['family'] == 'RedHat' &&
+                        !%w[Amazon Fedora].include?(os['name']) &&
                         ((os['release']['major'].to_i == 9 && os['release']['minor'].to_i >= 3) || (os['release']['major'].to_i >= 10))
 
     cmdline = [mkconfig_path]

--- a/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
@@ -22,6 +22,30 @@ describe Puppet::Type.type(:kernel_parameter).provider(:grub2) do
     allow(FileTest).to receive(:executable?).with('/usr/sbin/grub-mkconfig').and_return(true)
     expect(provider_class.mkconfig_path).to eq '/usr/sbin/grub-mkconfig'
   end
+
+  describe 'mkconfig_cmdline' do
+    before do
+      allow(FileTest).to receive_messages(file?: false, executable?: false)
+      allow(FileTest).to receive(:file?).with('/usr/sbin/grub2-mkconfig').and_return(true)
+      allow(FileTest).to receive(:executable?).with('/usr/sbin/grub2-mkconfig').and_return(true)
+    end
+
+    {
+      'RHEL 9.2' => [{ 'family' => 'RedHat', 'name' => 'RedHat', 'release' => { 'major' => '9', 'minor' => '2' } }, false],
+      'RHEL 9.3' => [{ 'family' => 'RedHat', 'name' => 'RedHat', 'release' => { 'major' => '9', 'minor' => '3' } }, true],
+      'RHEL 10' => [{ 'family' => 'RedHat', 'name' => 'RedHat', 'release' => { 'major' => '10', 'minor' => '0' } }, true],
+      'Amazon Linux 2023' => [{ 'family' => 'RedHat', 'name' => 'Amazon', 'release' => { 'major' => '2023', 'minor' => '0' } }, false],
+      'Fedora 42' => [{ 'family' => 'RedHat', 'name' => 'Fedora', 'release' => { 'major' => '42', 'minor' => '0' } }, false],
+      'Debian 12' => [{ 'family' => 'Debian', 'name' => 'Debian', 'release' => { 'major' => '12', 'minor' => '0' } }, false],
+    }.each do |os_desc, (os_fact, expected)|
+      it "#{expected ? 'passes' : 'omits'} --update-bls-cmdline on #{os_desc}" do
+        allow(Facter).to receive(:value).with(:os).and_return(os_fact)
+        expected_cmdline = ['/usr/sbin/grub2-mkconfig']
+        expected_cmdline << '--update-bls-cmdline' if expected
+        expect(provider_class.mkconfig_cmdline).to eq expected_cmdline
+      end
+    end
+  end
 end
 
 describe Puppet::Type.type(:kernel_parameter).provider(:grub2) do


### PR DESCRIPTION
#### Pull Request (PR) description
The BLS guard excluded Amazon Linux and Fedora on the assumption that neither has a release with major version 9. But it also accepts major >= 10, which Amazon Linux 2023 (major 2023) and Fedora (major 42) both satisfy, so the flag was added on exactly the platforms meant to be skipped. grub2 there does not support it, and kernel_parameter fails to flush with 'grub2-mkconfig: Usage:' and exit 1.

Exclude both by os.name instead of relying on version arithmetic.

