### PR TITLE
fix: escape dot in kernel_parameter names in self.instances

### DIFF
--- a/lib/puppet/provider/kernel_parameter/grub2.rb
+++ b/lib/puppet/provider/kernel_parameter/grub2.rb
@@ -15,15 +15,18 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
   lens { 'Shellvars_list.lns' }
 
   resource_path do |resource|
-    # https://github.com/voxpupuli/puppet-augeasproviders_grub/issues/124
-    # :name is treated as RegEx
-    # ipv6.disable is a very special case. We do not want '.' to be treated as RegEx.
-    # as of 2026, the dot '.' is the only RegEx-special character allowed in GRUB_CMDLINE_LINUX
-    # we will escape all dots, unless they are preceded by backspace
-    # dont blame this regex on me, blame it on rubocop
-    # gsub( %r@   (?<!\\)   \.   @x , '\.' )
-    regexescape = resource[:name].gsub(%r{(?<!\\)\.}, '\.')
-    "$target/#{section(resource)}/value[.=~regexp('^#{regexescape}(=.*)?$')]"
+    "$target/#{section(resource)}/value#{name_match(resource[:name])}"
+  end
+
+  # Augeas match predicate selecting the value nodes for exactly this parameter,
+  # i.e. '<name>' or '<name>=<anything>'. The dot in a name such as
+  # 'ipv6.disable' must match literally rather than as a regexp wildcard,
+  # otherwise sibling parameters are matched too. Issue #124.
+  #
+  # @param name [String] the parameter name
+  # @return [String] the predicate, including the enclosing brackets
+  def self.name_match(name)
+    "[.=~regexp('^#{name.gsub('.', '[.]')}(=.*)?$')]"
   end
 
   def self.mkconfig_path
@@ -80,7 +83,7 @@ Puppet::Type.type(:kernel_parameter).provide(:grub2, parent: Puppet::Type.type(:
 
         # Find all values for each param name
         params.each do |param|
-          vals = aug.match("$target/#{key}/value[.=~regexp('^#{param}(=.*)?$')]").map do |vp|
+          vals = aug.match("$target/#{key}/value#{name_match(param)}").map do |vp|
             aug.get(vp).split('=', 2)[1]
           end
           vals = vals[0] if vals.size == 1

--- a/spec/acceptance/00_kernel_parameter_spec.rb
+++ b/spec/acceptance/00_kernel_parameter_spec.rb
@@ -21,27 +21,27 @@ describe 'Kernel Parameter Tests' do
         }),
       test: %(grep -q "audit=1" /proc/cmdline),
     },
-    insert_ipv6: {
+    # The dot must not act as a wildcard: these two are managed independently.
+    insert_dotted_name: {
       manifest: %(
         kernel_parameter { 'ipv6.enable':
-          value => '1',
           ensure => 'present',
+          value  => '1',
         }
         kernel_parameter { 'ipv6_enable':
-          value => '1',
           ensure => 'present',
+          value  => '2',
         }
       ),
-      test: 'grep -q ipv6\.enable=1 /proc/commandline ',
+      test: %(grep -qF 'ipv6.enable=1' /proc/cmdline && grep -qF 'ipv6_enable=2' /proc/cmdline),
     },
-    remove_ignoring_regex: {
+    remove_dotted_name: {
       manifest: %(
         kernel_parameter { 'ipv6.enable':
-          value => '1',
           ensure => 'absent',
         }
       ),
-      test: 'grep -q ipv6_enable=1 /proc/commandline && grep -vq ipv6\.enable=1 /proc/commandline',
+      test: %(grep -qF 'ipv6_enable=2' /proc/cmdline && ! grep -qF 'ipv6.enable=1' /proc/cmdline),
     },
   }
 
@@ -61,7 +61,7 @@ describe 'Kernel Parameter Tests' do
             apply_manifest_on(host, manifest, catch_changes: true)
           end
 
-          it 'is expected to have auditing enabled at boot time' do
+          it 'is expected to have the parameters applied at boot time' do
             # Scrub out any custom boot entries that were added by other GRUB2
             # tests
             on(host, 'rm -rf /etc/grub.d/05_puppet_managed*')

--- a/spec/fixtures/unit/puppet/provider/kernel_parameter/grub2/dotted
+++ b/spec/fixtures/unit/puppet/provider/kernel_parameter/grub2/dotted
@@ -1,0 +1,4 @@
+GRUB_TIMEOUT=5
+GRUB_DEFAULT=saved
+GRUB_CMDLINE_LINUX="quiet ipv6.enable=1 ipv6_enable=2 ipv6Xenable=3"
+GRUB_CMDLINE_LINUX_DEFAULT="rhgb nohz=on"

--- a/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
+++ b/spec/unit/puppet/provider/kernel_parameter/grub2_spec.rb
@@ -418,6 +418,86 @@ describe Puppet::Type.type(:kernel_parameter).provider(:grub2) do
     end
   end
 
+  describe 'name_match' do
+    {
+      'quiet' => "[.=~regexp('^quiet(=.*)?$')]",
+      'ipv6.enable' => "[.=~regexp('^ipv6[.]enable(=.*)?$')]",
+      'a.b.c' => "[.=~regexp('^a[.]b[.]c(=.*)?$')]",
+    }.each do |name, expected|
+      it "matches #{name.inspect} with #{expected}" do
+        expect(provider_class.name_match(name)).to eq expected
+      end
+    end
+  end
+
+  context 'with dotted parameter names' do
+    let(:tmptarget) { aug_fixture('dotted') }
+    let(:target) { tmptarget.path }
+
+    before do
+      allow_any_instance_of(provider_class).to receive(:mkconfig).and_return('OK')
+    end
+
+    # instances() drives 'puppet resource' and 'resources { purge => true }', so
+    # an over-matched name reports a value that belongs to a sibling parameter.
+    it 'reports the value of only the exactly named parameter' do
+      allow(provider_class).to receive(:target).and_return(target)
+      inst = provider_class.instances.map { |p| [p.get(:name), p.get(:value)] }
+
+      expect(inst).to include(['ipv6.enable', '1'])
+      expect(inst).to include(%w[ipv6_enable 2])
+      expect(inst).to include(%w[ipv6Xenable 3])
+    end
+
+    it 'changes only the exactly named parameter' do
+      apply!(Puppet::Type.type(:kernel_parameter).new(
+               name: 'ipv6.enable',
+               ensure: :present,
+               value: '9',
+               target: target,
+               provider: 'grub2',
+             ))
+
+      augparse_filter(target, LENS, FILTER, '
+        { "GRUB_CMDLINE_LINUX"
+          { "quote" = "\"" }
+          { "value" = "quiet" }
+          { "value" = "ipv6.enable=9" }
+          { "value" = "ipv6_enable=2" }
+          { "value" = "ipv6Xenable=3" }
+        }
+        { "GRUB_CMDLINE_LINUX_DEFAULT"
+          { "quote" = "\"" }
+          { "value" = "rhgb" }
+          { "value" = "nohz=on" }
+        }
+      ')
+    end
+
+    it 'deletes only the exactly named parameter' do
+      apply!(Puppet::Type.type(:kernel_parameter).new(
+               name: 'ipv6.enable',
+               ensure: 'absent',
+               target: target,
+               provider: 'grub2',
+             ))
+
+      augparse_filter(target, LENS, FILTER, '
+        { "GRUB_CMDLINE_LINUX"
+          { "quote" = "\"" }
+          { "value" = "quiet" }
+          { "value" = "ipv6_enable=2" }
+          { "value" = "ipv6Xenable=3" }
+        }
+        { "GRUB_CMDLINE_LINUX_DEFAULT"
+          { "quote" = "\"" }
+          { "value" = "rhgb" }
+          { "value" = "nohz=on" }
+        }
+      ')
+    end
+  end
+
   context 'with broken file' do
     let(:tmptarget) { aug_fixture('broken') }
     let(:target) { tmptarget.path }


### PR DESCRIPTION
#### Pull Request (PR) description
#124 was only fixed in resource_path, so self.instances still matched 'ipv6.enable' against its siblings and reported their values. That is what 'puppet resource' and 'resources { purge => true }' read, so re-applying the reported state appended bogus entries to the cmdline.

Both call sites now share self.name_match. Also fixes the acceptance tests added in #134, which grepped /proc/commandline instead of /proc/cmdline.

#### This Pull Request (PR) fixes the following issues
Fixes #124
Fixes #134

